### PR TITLE
Fix spec failure

### DIFF
--- a/lib/context/materials.rb
+++ b/lib/context/materials.rb
@@ -128,11 +128,11 @@ module Context
 
 
     def setupExisting(environment, repo)
-      create_repo(environment, repo)
+      create_repo(environment, environment, repo)
     end
 
     def setup(environment, repo)
-      create_repo("#{environment}-#{SecureRandom.hex(4)}", repo)
+      create_repo(environment, "#{environment}-#{SecureRandom.hex(4)}", repo)
     end
 
     def create_environment(material)
@@ -156,9 +156,9 @@ module Context
       end
     end
 
-    def create_repo(environment, repo)
+    def create_repo(environment, environment_unique_name, repo)
       @path = "#{GoConstants::TEMP_DIR}/gitconfig-#{Time.now.to_i}"
-      @environment_name = environment
+      @environment_name = environment_unique_name
       rm_rf(@path)
       mkdir_p(@path)
       cd(@path) do

--- a/lib/context/scenario_state.rb
+++ b/lib/context/scenario_state.rb
@@ -65,8 +65,8 @@ module Context
       @scenario_store.put "#{entity}-configrepo", repo
     end
 
-    def configrepo(pipeline)
-      @scenario_store.get "#{pipeline}-configrepo"
+    def configrepo(entity)
+      @scenario_store.get "#{entity}-configrepo"
     end
   end
 end


### PR DESCRIPTION
Pass along both environment name and the unique environment name for setting up a config repo environment
Issue caused due to looking for environment using unique_name instead of name into the scenario_state