### PR TITLE
Use specific version of gauge-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'gauge-ruby'
+gem 'gauge-ruby', '~> 0.3.1'
 gem 'test-unit'
 gem 'selenium-webdriver', '~> 2.53'
 gem 'childprocess'


### PR DESCRIPTION
Need 0.3.1 version of gauge ruby to be run on gauge version 0.7.0