### PR TITLE
Add data sharing SPA specs

### DIFF
--- a/lib/helpers/spec_helper.rb
+++ b/lib/helpers/spec_helper.rb
@@ -31,6 +31,7 @@ require 'context/pipeline'
 require 'context/ldap'
 require 'pages/app_base'
 require 'pages/login_page'
+require 'pages/data_sharing_spa'
 require 'pages/agents_spa'
 require 'pages/pipeline_dashboard_page'
 require 'pages/environments_page'
@@ -58,6 +59,10 @@ module Helpers
 
     def login_page
       Pages::Login.new
+    end
+
+    def data_sharing_spa_page
+      Pages::DataSharingSPA.new
     end
 
     def agents_spa_page

--- a/lib/pages/data_sharing_spa.rb
+++ b/lib/pages/data_sharing_spa.rb
@@ -1,0 +1,52 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module Pages
+  class DataSharingSPA < AppBase
+    set_url "#{GoConstants::GO_SERVER_BASE_URL}/admin/data_sharing/settings"
+
+    element :data_sharing_toggle, '#consentSwitch'
+    element :switch_paddle, '.switch-paddle'
+    element :save_button, '.update-consent'
+    element :reset_button, '.reset-consent'
+    element :updated_by_info, '.updated-by'
+    element :shared_data_info, '.shared-data'
+
+    def is_data_sharing_allowed
+      data_sharing_toggle.checked?
+    end
+
+    def toggle_data_sharing
+      switch_paddle.click
+    end
+
+    def save
+      save_button.click
+    end
+
+    def reset
+      reset_button.click
+    end
+
+    def get_updated_by_message
+      updated_by_info.text
+    end
+
+    def get_data_that_will_be_shared
+      shared_data_info.text
+    end
+  end
+end

--- a/specs/DataSharing.spec
+++ b/specs/DataSharing.spec
@@ -6,7 +6,8 @@ DataSharing
 tags: data_sharing_spa, SPA
 
 Setup of contexts
-* Basic Configuration - setup
+* Secure Configuration - setup
+* Login as "admin" - setup
 * Capture go state "DataSharing" - setup
 
 * On Data Sharing SPA
@@ -15,11 +16,13 @@ Setup of contexts
 * Toggle data sharing
 * Save the permissions
 * Verify data sharing consent is "not allowed"
-* Verify data sharing permissions are updated by "anonymous" user
+* Verify data sharing permissions are updated by "admin" user
 * Toggle data sharing
 * Reset the permissions
 * Verify data sharing consent is "not allowed"
 
 teardown
 _______________
+* As user "admin" for teardown
 * Capture go state "DataSharing" - teardown
+* Logout - from any page

--- a/specs/DataSharing.spec
+++ b/specs/DataSharing.spec
@@ -1,0 +1,25 @@
+DataSharing
+=========
+
+DataSharing
+-------------------
+tags: data_sharing_spa, SPA
+
+Setup of contexts
+* Basic Configuration - setup
+* Capture go state "DataSharing" - setup
+
+* On Data Sharing SPA
+* Verify data sharing consent is "allowed"
+* Verify data that will be shared is visible
+* Toggle data sharing
+* Save the permissions
+* Verify data sharing consent is "not allowed"
+* Verify data sharing permissions are updated by "anonymous" user
+* Toggle data sharing
+* Reset the permissions
+* Verify data sharing consent is "not allowed"
+
+teardown
+_______________
+* Capture go state "DataSharing" - teardown

--- a/step_implementations/specs/data_sharing_spa_spec.rb
+++ b/step_implementations/specs/data_sharing_spa_spec.rb
@@ -1,0 +1,64 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+USAGE_DATA_API_VERSION = 'application/vnd.go.cd.v1+json'.freeze
+
+step 'On Data Sharing SPA' do |_count|
+  data_sharing_spa_page.load
+end
+
+step 'Toggle data sharing' do
+  data_sharing_spa_page.toggle_data_sharing
+end
+
+step 'Save the permissions' do
+  data_sharing_spa_page.save
+end
+
+step 'Reset the permissions' do
+  data_sharing_spa_page.reset
+end
+
+step 'Verify data that will be shared is visible' do
+  begin
+    response = RestClient.get http_url("/api/internal/data_sharing/usagedata"), { accept: USAGE_DATA_API_VERSION }.merge(basic_configuration.header)
+  rescue RestClient::ExceptionWithResponse => err
+    raise "Failed to get the data sharing usagedata information. Returned response code - #{err.response.code}"
+  end
+
+  verify_usage_data_displayed_info(response, data_sharing_spa_page.get_data_that_will_be_shared)
+end
+
+step 'Verify data sharing permissions are updated by <user> user' do |user|
+  msg ="#{user} changed the data sharing permission on 15 Jun 2018."
+  assert_equal msg, data_sharing_spa_page.get_updated_by_message, "Expected data sharing permissions to be updated by user #{user}"
+end
+
+step 'Verify data sharing consent is <isAllowed>' do |isAllowed|
+  if isAllowed.eql? 'allowed'
+    assert_equal true, data_sharing_spa_page.is_data_sharing_allowed, "Expected data sharing consent to be allowed"
+  else
+    assert_equal false, data_sharing_spa_page.is_data_sharing_allowed, "Expected data sharing consent to be not allowed"
+  end
+end
+
+def verify_usage_data_displayed_info(response, displayed_info)
+   response_body = response.body
+   expected = JSON.parse(response_body)['_embedded']
+   actual = JSON.parse(displayed_info)
+
+   assert_equal expected, actual, "Expected data being shared to be visible. Original_Data: #{expected}. Displayed_Data: #{actual}"
+end

--- a/step_implementations/specs/data_sharing_spa_spec.rb
+++ b/step_implementations/specs/data_sharing_spa_spec.rb
@@ -43,8 +43,8 @@ step 'Verify data that will be shared is visible' do
 end
 
 step 'Verify data sharing permissions are updated by <user> user' do |user|
-  msg ="#{user} changed the data sharing permission on 15 Jun 2018."
-  assert_equal msg, data_sharing_spa_page.get_updated_by_message, "Expected data sharing permissions to be updated by user #{user}"
+  msg ="#{user} changed the data sharing permission"
+  assert_true data_sharing_spa_page.get_updated_by_message.include? msg
 end
 
 step 'Verify data sharing consent is <isAllowed>' do |isAllowed|


### PR DESCRIPTION
* Verify admin users can toggle the information
* Verify save and reset permission operations
* Verify the data being displayed is the same data that /data_sharing/usagedata API returns