### PR TITLE
Fix data sharing spec

### DIFF
--- a/step_implementations/specs/data_sharing_spa_spec.rb
+++ b/step_implementations/specs/data_sharing_spa_spec.rb
@@ -57,7 +57,7 @@ end
 
 def verify_usage_data_displayed_info(response, displayed_info)
    response_body = response.body
-   expected = JSON.parse(response_body)['_embedded']
+   expected = JSON.parse(response_body)
    actual = JSON.parse(displayed_info)
 
    assert_equal expected, actual, "Expected data being shared to be visible. Original_Data: #{expected}. Displayed_Data: #{actual}"


### PR DESCRIPTION
* Remove '_embedded' from data sharing usage data api response validation