### PR TITLE
Trigger pipeline can be used in multiple ways

### DIFF
--- a/lib/pages/new_pipeline_dashboard_page.rb
+++ b/lib/pages/new_pipeline_dashboard_page.rb
@@ -33,20 +33,13 @@ module Pages
 
     load_validation { has_pipeline_group? }
 
-    def trigger_pipeline(wait_to_build = true)
-      (pipeline_name text: scenario_state.self_pipeline)
+    def trigger_pipeline(name: scenario_state.self_pipeline, wait_to_build: true)
+      (pipeline_name text: name)
         .find(:xpath, '../..').find('.pipeline_btn.play').click
       if wait_to_build
         reload_page
         wait_till_pipeline_start_building
       end
-    end
-
-    def trigger_pipeline(name)
-      (pipeline_name text: name)
-        .find(:xpath, '../..').find('.pipeline_btn.play').click
-      reload_page
-      wait_till_pipeline_start_building
     end
 
     def trigger_pipeline_disabled?

--- a/step_implementations/specs/new_pipeline_dashboard_spec.rb
+++ b/step_implementations/specs/new_pipeline_dashboard_spec.rb
@@ -55,7 +55,7 @@ step 'Trigger and cancel stage <defaultStage> <trigger_number> times' do |stage_
 end
 
 step 'Trigger and wait for stage <stage> is <state> with label <label> - On Swift Dashboard page' do |stage, state, label|
-  new_pipeline_dashboard_page.trigger_pipeline(false)
+  new_pipeline_dashboard_page.trigger_pipeline(wait_to_build: false)
   new_pipeline_dashboard_page.wait_till_pipeline_complete
   new_pipeline_dashboard_page.verify_pipeline_stage_state scenario_state.self_pipeline, stage, state.downcase
   new_pipeline_dashboard_page.verify_pipeline_is_at_label scenario_state.self_pipeline, label

--- a/step_implementations/specs/pipeline_selection_spec.rb
+++ b/step_implementations/specs/pipeline_selection_spec.rb
@@ -141,5 +141,5 @@ step 'Select filter state <state>' do |state|
 end
 
 step 'Trigger pipeline <name> - On Swift Dashboard page' do |name|
-  new_pipeline_dashboard_page.trigger_pipeline(name)
+  new_pipeline_dashboard_page.trigger_pipeline(name: name)
 end


### PR DESCRIPTION
So using named params to make method flexible to use in different specifications