### PR TITLE
Verify env vars after fetching an external artifact

### DIFF
--- a/lib/pages/job_settings_page.rb
+++ b/lib/pages/job_settings_page.rb
@@ -33,6 +33,7 @@ module Pages
     element :task_configuration_path, "input[name='task[configuration][Path]']"
     element :task_working_directory, "input[name='task[workingDirectory]']"
     element :task_target, "input[name='task[target]']"
+    element :tasks_list, "table.tasks_list_table"
 
 
     load_validation { has_add_new_task? }
@@ -46,6 +47,14 @@ module Pages
     def configure_rake_task(target,working_directory)
       task_target.set(target)
       task_working_directory.set(working_directory)
+    end
+
+    def move_task_down(task_index)
+      tasks_list.find("tbody tr.task_#{task_index} button.promote_button .promote_down").ancestor('button.promote_button').click
+    end
+
+    def move_task_up(task_index)
+      tasks_list.find("tbody tr.task_#{task_index} button.promote_button .promote_up").ancestor('button.promote_button').click
     end
   end
 end

--- a/resources/config/external-artifacts-cruise-config.xml
+++ b/resources/config/external-artifacts-cruise-config.xml
@@ -84,6 +84,10 @@
                     <exec command="sleep" >
                         <arg>10</arg>
                     </exec>
+                    <exec command="/bin/bash" >
+                      <arg>-c</arg>
+                      <arg>env; echo "VAR1=$(echo "CHANGED_${VAR1}" | tr 1 X)"</arg>
+                    </exec>
                     </tasks>
                 </job>
                 </jobs>

--- a/specs/ExternalArtifacts.spec
+++ b/specs/ExternalArtifacts.spec
@@ -25,6 +25,7 @@ Setup of contexts
 * Add task "Fetch Artifact"
 * Select artifact type "External" pipeline "upstream" stage "defaultStage" job "defaultJob" artifact id "test_artifact" path "test_folder"
 * Save task details
+* Move task "2" up
 
 
 * Looking at pipeline "upstream" - On Swift Dashboard page
@@ -41,7 +42,13 @@ Setup of contexts
 
 * On Job details page of pipeline "downstream" counter "1" stage "defaultStage" counter "1" job "defaultJob"
 * Verify console log contains message "Fetching pluggable artifact using plugin cd.go.artifact.dummy"
+* Verify console log contains message "NOTE: Setting new environment variable: VAR1 = ********"
+* Verify console log contains message "NOTE: Setting new environment variable: VAR2 = VALUE2"
+* Verify console log contains message "WARNING: Replacing environment variable: GO_JOB_NAME = new job name (previously: defaultJob)"
 
+* Verify console log contains message "VAR1=CHANGED_VALUEX"
+* Verify console log contains message "VAR2=VALUE2"
+* Verify console log contains message "GO_JOB_NAME=new job name"
 
 teardown
 _______________

--- a/step_implementations/specs/job_settings_spec.rb
+++ b/step_implementations/specs/job_settings_spec.rb
@@ -45,6 +45,14 @@ step 'Add task <task_name>' do |task|
   job_settings_page.add_new_task_of_type task
 end
 
+step 'Move task <task_index> up' do |task_index|
+  job_settings_page.move_task_up task_index
+end
+
+step 'Move task <task_index> down' do |task_index|
+  job_settings_page.move_task_down task_index
+end
+
 step 'Select artifact type <a_type> pipeline <p_name> stage <s_name> job <j_name> artifact id <a_id> path <path>' do |a_type, p_name, s_name, j_name, a_id, path|
   job_settings_page.external_artifact.click
   job_settings_page.task_pipeline.set scenario_state.actual_pipeline_name(p_name)


### PR DESCRIPTION
Verify env var being set, secure env var being set and a replacement of an existing env var.

Also, add the ability to move a task up and down within a job.