### PR TITLE
Always load dashboard page and then logout

### DIFF
--- a/lib/pages/app_base.rb
+++ b/lib/pages/app_base.rb
@@ -32,14 +32,9 @@ module Pages
     end
 
     def logout
-      if page.has_css? ('.current_user_name')
-        page.find('.current_user_name').hover
-        page.find('.logout').click
-      else
-        new_pipeline_dashboard_page.load
-        page.find('.current-user.opens-left').hover
-        page.find('a', text: 'Sign out').click
-      end
+      new_pipeline_dashboard_page.load
+      page.find('.current-user.opens-left').hover
+      page.find('a', text: 'Sign out').click
     end
 
     def menu_item_visible(item)


### PR DESCRIPTION
This is to avoid differences with logout view on old pages and new pages