### PR TITLE
Small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Badge](https://cdn.rawgit.com/getgauge/getgauge.github.io/master/Gauge_Badge.svg
 * Build GoCD server and agent zip installers - cd to ```gocd``` and run: ```./gradlew clean installers:agentGenericZip installers:serverGenericZip test:test-addon:assemble```
 * Build GoCD plugins api - cd to ```gocd``` and run :
 ```./gradlew -PfastBuild --parallel --max-workers 2 clean plugin-infra:go-plugin-api:install plugin-infra:go-plugin-api-internal:install installers:versionFile```
-* Build go plugins - cd to ```go-plugins``` and run: ```./gradlew clean assemble copyJarsToOnePlace -PgoVersion=(jq '.go_full_version' -r ../gocd/installers/target/distributions/meta/version.json)```
+* Build go plugins - cd to ```go-plugins``` and run: ```./gradlew clean assemble copyJarsToOnePlace -PgoVersion=$(jq '.go_full_version' -r ../gocd/installers/target/distributions/meta/version.json)```
 * cd to ```ruby-functional-tests``` and run : ```$ bundle install --path=vendor/bundle```
 * To clean, prepare server and agent for functional test execute this command ```bundle exec rake GO_VERSION='X.x.x' clean_test server:prepare agent:prepare```
 * To run all specs execute this command ```bundle exec rake GO_VERSION='X.x.x' GAUGE_TAGS='<spec tags to run> test'```

--- a/lib/pages/new_pipeline_dashboard_page.rb
+++ b/lib/pages/new_pipeline_dashboard_page.rb
@@ -86,6 +86,7 @@ module Pages
         .ancestor('.pipeline').find('.pipeline_instance', wait: 30).find('.pipeline_stages').all('a')
     rescue StandardError => e
       p 'Looks like Pipeline still not started, trying after page reload...'
+      nil
     end
 
     def get_pipeline_stage_state(pipeline, stagename) # This need relook too


### PR DESCRIPTION
* If you do not return nil at the end of the method, it will return the string in the message
  as the return value, and will fail callers who expect nil or a Capybara::Result object.