### PR TITLE
Fix User summary page message

### DIFF
--- a/specs/DrainModeSPA.spec
+++ b/specs/DrainModeSPA.spec
@@ -63,6 +63,9 @@ Setup of contexts
 
 * Attempt to pause pipline "basic-pipeline-fast" with cause "gauge testing it" and should return with http status "503"
 
+* Looking at pipeline "timer-triggered" - On Swift Dashboard page
+* Using timer with spec "0 0/30 * 1/1 * ? *"
+
 * On Drain mode SPA
 * Disable drain mode
 

--- a/specs/EnableDisableUsers.spec
+++ b/specs/EnableDisableUsers.spec
@@ -46,7 +46,7 @@ Setup of contexts
 * Promote "user2" an admin user
 
 * Disable users "admin,user2,user1"
-* Verify error message "Did not disable any of the selected users. Ensure that all configured admins are not being disabled." is displayed
+* Verify error message "There must be atleast one admin user enabled!" is displayed
 
 
 

--- a/step_implementations/initialize.rb
+++ b/step_implementations/initialize.rb
@@ -48,7 +48,7 @@ Gauge.configure do |config|
     Capybara.page.save_screenshot
     file = File.open(Dir.glob('screenshots/*.png').first, 'rb')
     file_content = File.binread(file.path)
-    FileUtils.rm_r 'screenshots', force: true
+    #FileUtils.rm_r 'screenshots', force: true
     return file_content
   }
 end


### PR DESCRIPTION
Do not delete screen shots folder. export it as artifact in jobs that are needed. Currently gauge html plugin is not showing up screenshot in the report