### PR TITLE
Increasing wait times just to understand why drain mode spec is faili…

### DIFF
--- a/lib/pages/drain_mode_spa.rb
+++ b/lib/pages/drain_mode_spa.rb
@@ -36,12 +36,12 @@ module Pages
     end
 
     def cancel_stage(pipeline, pipeline_counter, stage, stage_counter)
-      page.find('div[data-test-id="in-progress-subsystems"]', wait: 20).find("button[data-test-id='cancel-stage-btn-for-#{pipeline}/#{pipeline_counter}/#{stage}/#{stage_counter}']", wait: 20).click
+      page.find('div[data-test-id="in-progress-subsystems"]', wait: 60).find("button[data-test-id='cancel-stage-btn-for-#{pipeline}/#{pipeline_counter}/#{stage}/#{stage_counter}']", wait: 20).click
       reload_page
     end
 
     def stage_in_inprogress_subsystem(pipeline, pipeline_counter, stage, stage_counter)
-      page.find('div[data-test-id="in-progress-subsystems"]', wait: 20).has_css?("button[data-test-id='cancel-stage-btn-for-#{pipeline}/#{pipeline_counter}/#{stage}/#{stage_counter}']", wait: 20)
+      page.find('div[data-test-id="in-progress-subsystems"]', wait: 60).has_css?("button[data-test-id='cancel-stage-btn-for-#{pipeline}/#{pipeline_counter}/#{stage}/#{stage_counter}']", wait: 20)
     end
 
     def switch_drain_mode
@@ -60,7 +60,5 @@ module Pages
     def disable_drain_mode
       switch_drain_mode if drain_mode_enabled?
     end
-
-
   end
 end

--- a/step_implementations/initialize.rb
+++ b/step_implementations/initialize.rb
@@ -59,6 +59,7 @@ end
 
 Capybara.configure do |config|
   config.save_path = 'screenshots'
+  config.default_max_wait_time = 60
 end
 
 Capybara.register_driver :selenium do |app|


### PR DESCRIPTION
…ng on pipeline

https://build.gocd.org/go/files/regression-SPAs/1143/Firefox/3/drain-mode/screenshots/screenshots/capybara-201901071013264500024680.png

As this screenshot shows the drain mode page do not show the inprogress sub systems as expected. Its not reproducible locally. So increasing these waits just to see if they have any effect