### PR TITLE
Add folder screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor/bundle/
 .gauge/
 *.lock
 .vscode
+screenshots/*.png


### PR DESCRIPTION
Even if gauge fails to show up the screenshots on html report, this folder will have the screenshot grabbed during test failure