### PR TITLE
Fixed text broken by pipeline export

### DIFF
--- a/lib/pages/admin_pipeline_page.rb
+++ b/lib/pages/admin_pipeline_page.rb
@@ -39,7 +39,7 @@ module Pages
     def move_pipeline(pipeline, _source_group, destination_group)
       pipeline_row = row_for_pipeline(pipeline)
       pipeline_row.find('.move_pipeline').click
-      page.find('#div_move_to_groups').find('ul li.move_to_group_option', {text: destination_group}).click
+      page.find('#shared_micro_dropdown').find('ul li.move_to_group_option', {text: destination_group}).click
     end
 
     def verify_number_of_error_message(number_of_err_msg)


### PR DESCRIPTION
This is related to https://github.com/gocd/gocd/issues/5688. 

The dropdown for moving pipelines is actually present, but the id was changed (as part of the pipeline export work) so the css selector used in the test is no longer accurate. We chose to change the id because the same div is used for both the pipeline export dropdown list and the move to dropdown list. We wanted to make the id more general. 

This should fix the test broken as a result of the change.