### PR TITLE
Enable toggle  - users_page_using_rails - in specs

### DIFF
--- a/lib/context/basic_configuration.rb
+++ b/lib/context/basic_configuration.rb
@@ -154,15 +154,9 @@ module Context
       RestClient.post delete_all_users_url, header
     end
 
-    def enable_toggle(toggle)
+    def update_toggle(toggle, value)
       RestClient.post http_url("/api/admin/feature_toggles/#{toggle}"),
-                      '{"toggle_value": "on"}',
-                      { content_type: :json }.merge(basic_configuration.header)
-    end
-
-    def disable_toggle(toggle)
-      RestClient.post http_url("/api/admin/feature_toggles/#{toggle}"),
-                      '{"toggle_value": "off"}',
+                      {"toggle_value": "#{value}"}.to_json,
                       { content_type: :json }.merge(basic_configuration.header)
     end
 
@@ -316,6 +310,6 @@ module Context
       end
       return roles
     end
- 
+
   end
 end

--- a/specs/AdminPermissionsNewUsers.spec
+++ b/specs/AdminPermissionsNewUsers.spec
@@ -9,6 +9,7 @@ tags: admin_permissions, with_security
 Setup of contexts
 * Basic Configuration - setup
 * With "1" live agents - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Capture go state "AdminPermissionsNewUsers" - setup
 
 * Enable security with password file
@@ -18,7 +19,7 @@ Verify if user is admin
 * VerifyIfUserHasRole
      |login as user|admin?|
      |-------------|------|
-     |pavan        |true  | 
+     |pavan        |true  |
      |raghu        |true  |
      |admin        |true  |
 
@@ -33,4 +34,4 @@ _______________
 * Capture go state "AdminPermissionsNewUsers" - teardown
 * With "1" live agents - teardown
 * Logout - from any page
-
+* Update toggle "users_page_using_rails" to value "off"

--- a/specs/AssociateUsersWithRoles.spec
+++ b/specs/AssociateUsersWithRoles.spec
@@ -6,6 +6,7 @@ Setup of contexts
 * With no users - setup
 * Secure Configuration - setup
 * Login as "admin" - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Capture go state "AssociateUsersWithRoles" - setup
 
 AssociateUsersWithRoles
@@ -39,8 +40,7 @@ tags: admin, role
 
 Teardown of contexts
 ____________________
+* As user "admin" for teardown
 * Capture go state "AssociateUsersWithRoles" - teardown
 * Logout - from any page
-
-
-
+* Update toggle "users_page_using_rails" to value "off"

--- a/specs/DisabledUserAccess.spec
+++ b/specs/DisabledUserAccess.spec
@@ -5,6 +5,7 @@ Setup of contexts
 * With no users - setup
 * Secure Configuration - setup
 * Login as "admin" - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Using pipeline "basic-pipeline-fast" - setup
 * With "1" live agents - setup
 * Capture go state "DisabledUserAccess" - setup
@@ -47,6 +48,4 @@ ____________________
 * Capture go state "DisabledUserAccess" - teardown
 * With "1" live agents - teardown
 * Logout - from any page
-
-
-
+* Update toggle "users_page_using_rails" to value "off"

--- a/specs/EnableDisableUsers.spec
+++ b/specs/EnableDisableUsers.spec
@@ -12,6 +12,7 @@ Setup of contexts
 * With no users - setup
 * Secure Configuration - setup
 * Login as "admin" - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Capture go state "EnableDisableUsers" - setup
 
 * On User Summary page
@@ -55,3 +56,4 @@ ____________________
 * As user "admin" for teardown
 * Capture go state "EnableDisableUsers" - teardown
 * Logout - from any page
+* Update toggle "users_page_using_rails" to value "off"

--- a/specs/SystemAdminPrivilegeToggling.spec
+++ b/specs/SystemAdminPrivilegeToggling.spec
@@ -5,6 +5,7 @@ Setup of contexts
 * With no users - setup
 * Secure Configuration - setup
 * Login as "admin" - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Capture go state "SystemAdminPrivilegeToggling" - setup
 
 SystemAdminPrivilegeToggling
@@ -67,7 +68,7 @@ tags: admin, role, user_summary
 
 Teardown of contexts
 ____________________
+* As user "admin" for teardown
 * Capture go state "SystemAdminPrivilegeToggling" - teardown
 * Logout - from any page
-
-
+* Update toggle "users_page_using_rails" to value "off"

--- a/specs/UserAPI.spec
+++ b/specs/UserAPI.spec
@@ -5,6 +5,7 @@ Setup of contexts
 * With no users - setup
 * Secure Configuration - setup
 * Login as "admin" - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Capture go state "UserAPI" - setup
 
 UserAPI
@@ -37,7 +38,7 @@ tags: api, users
 
 Teardown of contexts
 ____________________
+* As user "admin" for teardown
 * Capture go state "UserAPI" - teardown
 * Logout - from any page
-
-
+* Update toggle "users_page_using_rails" to value "off"

--- a/step_implementations/specs/common_spec.rb
+++ b/step_implementations/specs/common_spec.rb
@@ -69,3 +69,7 @@ step 'Restart server' do ||
   go_server.wait_to_start
   app_base_page.reload_page
 end
+
+step 'Update toggle <toggle> to value <value>' do |toggle, value|
+  basic_configuration.update_toggle toggle, value
+end


### PR DESCRIPTION
Specs will for now run with the user summary page on rails. Once we complete manual verification of the new user summary page, will modify spec to run on new page. Also need to add more steps  to validate new features like filters, search