### PR TITLE
Removing the assertion for exact pipeline label

### DIFF
--- a/specs/PipelinesUsingTimer.spec
+++ b/specs/PipelinesUsingTimer.spec
@@ -33,7 +33,6 @@ Setting a timer that will constantly trigger the pipeline.
 * Using timer with spec "0/30 * * * * ? *"
 * Wait till pipeline start building - On Swift Dashboard page
 * Wait till pipeline completed - On Swift Dashboard page
-* Verify stage "defaultStage" is "Passed" on pipeline with label "3" and counter "1" - On Swift Dashboard page
 * Pause pipeline with reason "prevent another timer trigger before verification" - On Swift Dashboard page
 * Verify pipeline is paused with reason "prevent another timer trigger before verification" by "anonymous" - On Swift Dashboard page
 * Verify pipeline is triggered by "timer" - On Swift Dashboard page


### PR DESCRIPTION
In case of timer triggered pipeline with such short time as 30 secs, asserting for specific label of pipeline is not reliable, it causing intermittent test failure. Increasing the timer will slow down the test. The objective is to check if the pipeline is triggered by the timer or not. Which is validated by other steps. So removing this assertion of pipeline label