### PR TITLE
Fix teardown for SecretConfigAPI spec

### DIFF
--- a/specs/SecretConfigAPI.spec
+++ b/specs/SecretConfigAPI.spec
@@ -29,6 +29,6 @@ tags: secret_config, admin, api
 Teardown
 _______________
 * As user "admin" for teardown
-* Capture go state "PluginInfoAPI" - teardown
+* Capture go state "SecretConfigAPI" - teardown
 * Logout - from any page
 


### PR DESCRIPTION
Fixes: SecretConfigAPI has wrong label for Capture state.