### PR TITLE
Add file based secrets plugin for SecretConfigAPI spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ DOCKER_REGISTRY_ARTIFACT_PLUGIN_RELEASE_URL = ENV['DOCKER_REGISTRY_ARTIFACT_PLUG
 TEST_EXTERNAL_ARTIFACTS_PLUGIN_RELEASE_URL  = ENV['TEST_EXTERNAL_ARTIFACTS_PLUGIN_RELEASE_URL'] || 'https://api.github.com/repos/gocd-contrib/test-external-artifacts-plugin/releases/latest'
 ANALYTICS_PLUGIN_DOWNLOAD_URL               = ENV['ANALYTICS_PLUGIN_DOWNLOAD_URL']
 LDAP_AUTHORIZATION_PLUGIN_DOWNLOAD_URL      = ENV['LDAP_AUTHORIZATION_PLUGIN_DOWNLOAD_URL']
+FILE_BASED_SECRET_PLUGIN_RELEASE_URL        = ENV['FILE_BASED_SECRET_PLUGIN_RELEASE_URL'] || 'https://api.github.com/repos/gocd/gocd-file-based-secrets-plugin/releases/16812414'
 
 desc 'cleans all directories'
 task :clean_all do
@@ -150,6 +151,8 @@ namespace :plugins do
     sh "wget --quiet #{url} -O target/go-server-#{VERSION_NUMBER}/plugins/external/docker-swarm-ealstic-agents-plugin.jar"
     url = JSON.parse(open(DOCKER_EA_PLUGIN_RELEASE_URL).read)['assets'][0]['browser_download_url']
     sh "wget --quiet #{url} -O target/go-server-#{VERSION_NUMBER}/plugins/external/docker-ealstic-agents-plugin.jar"
+    url = JSON.parse(open(FILE_BASED_SECRET_PLUGIN_RELEASE_URL).read)['assets'][0]['browser_download_url']
+    sh "wget --quiet #{url} -O target/go-server-#{VERSION_NUMBER}/plugins/external/gocd-file-based-secrets-plugin.jar"
   end
 
   desc 'task for preparing anlytics plugin'

--- a/step_implementations/specs/secret_config_api.rb
+++ b/step_implementations/specs/secret_config_api.rb
@@ -63,7 +63,7 @@ step 'Add secret config <config_id> should return code <code>', 'Adding duplicat
   req_body = %({
     "id": "#{secret_config_id}",
     "description": "This is used to lookup for secrets for the team Dev team.",
-    "plugin_id": "cd.go.secrets.file",
+    "plugin_id": "cd.go.secrets.file-based-plugin",
     "properties": [
       {
         "key": "secrets_file_path",
@@ -101,7 +101,7 @@ step 'Update secret config <config_id> to <directive> usage only in pipeline gro
   req_body = %({
     "id": "#{config_id}",
     "description": "This is used to lookup for secrets for the team Dev team.",
-    "plugin_id": "cd.go.secrets.file",
+    "plugin_id": "cd.go.secrets.file-based-plugin",
     "properties": [
       {
         "key": "secrets_file_path",


### PR DESCRIPTION
This is required for plugin side validation that takes place while creating or updating secret config. Without plugin creation will fail with plugin missing error.