### PR TITLE
Fixes load validation failures

### DIFF
--- a/lib/pages/data_sharing_spa.rb
+++ b/lib/pages/data_sharing_spa.rb
@@ -18,7 +18,7 @@ module Pages
   class DataSharingSPA < AppBase
     set_url "#{GoConstants::GO_SERVER_BASE_URL}/admin/data_sharing/settings"
 
-    element :data_sharing_toggle, '#consentSwitch'
+    element :data_sharing_toggle, '.consent-toggle'
     element :switch_paddle, '.switch-paddle'
     element :save_button, '.update-consent'
     element :reset_button, '.reset-consent'

--- a/lib/pages/new_pipeline_dashboard_page.rb
+++ b/lib/pages/new_pipeline_dashboard_page.rb
@@ -23,6 +23,7 @@ module Pages
 
     element :pipeline_name, '.pipeline_name'
     elements :pipeline_group, '.dashboard-group'
+    element :dashboard_container, '.dashboard-container'
     elements :pipeline_group_title, '.dashboard-group_name'
     element :material_for_trigger, '.material-for-trigger'
     iframe :build_time_chart, PipelineBuildTime, 0
@@ -31,7 +32,7 @@ module Pages
     element :environment_variables_key_value, '.environment-variables.plain.key-value-pair'
     element :environment_variables_secure_key_value, '.environment-variables.secure.key-value-pair'
 
-    load_validation { has_pipeline_group? }
+    load_validation { has_dashboard_container? }
 
     def admin?
       menu_item_visible('admin')

--- a/lib/pages/personal_access_token_page.rb
+++ b/lib/pages/personal_access_token_page.rb
@@ -25,7 +25,7 @@ module Pages
     element :tab_revoked_tokens, "[data-test-id='tab-header-1']"
     element :table_access_tokens, "[data-test-id='table-body']"
 
-    load_validation { has_generate_token? }
+    load_validation { has_btn_generate_token? }
 
     def generate_token(description = '')
       btn_generate_token.click

--- a/lib/pages/plugins_spa.rb
+++ b/lib/pages/plugins_spa.rb
@@ -24,7 +24,7 @@ module Pages
     element :max_docker_containers, "input[ng-model='max_docker_containers']"
     element :docker_uri, "input[ng-model='docker_uri']"
 
-    load_validation {has_plugin_settings?}
+    load_validation { has_plugin_list_wrapper? }
 
     def invalid_plugin_message_exists?(id, message)
       plugin_to_test(id).find('[data-test-id="key-value-value-there-were-errors-loading-the-plugin"]').has_selector?('pre', text: message)

--- a/lib/pages/server_backup_page.rb
+++ b/lib/pages/server_backup_page.rb
@@ -19,8 +19,9 @@ module Pages
     set_url "#{GoConstants::GO_SERVER_BASE_URL}/admin/backup"
 
     element :btn_confirm_backup, '[data-test-id="button-save"]'
+    element :btn_perform_backup, '[data-test-id="perform-backup"]'
 
-    load_validation { has_perform_backup? }
+    load_validation { has_btn_perform_backup? }
 
     def perform_backup()
       page.find('button', text: 'Perform Backup').click(wait: 10)

--- a/lib/pages/server_health_messages.rb
+++ b/lib/pages/server_health_messages.rb
@@ -21,7 +21,7 @@ module Pages
     element :health_messages, '[data-test-id="modal-body"]'
 
     def verify_message_notifier_showsup
-      wait_until_message_notifier_visible(60)
+      wait_until_message_notifier_visible(wait: 60)
     end
 
     def verify_message_displayed(msg)

--- a/lib/pages/user_summary.rb
+++ b/lib/pages/user_summary.rb
@@ -92,7 +92,7 @@ module Pages
 
     def admin?(user, expected='Yes')
       (username text: user ,exact_text: true).ancestor('.user').find('.is_admin')['title'].eql?expected
-    end  
+    end
 
     def error_msg_displayed? message
       page.find('.error').text.eql? message
@@ -128,9 +128,9 @@ module Pages
     end
 
     def get_user_roles(user)
-      (username text: user,exact_text: true).ancestor('.user').find('.selector').sibling('.roles').find('span').text  
+      (username text: user,exact_text: true).ancestor('.user').find('.selector').sibling('.roles').find('span').text
     end
-    
+
     def add_new_roles_to_users(new_role,users)
       users.split(',').each { |user| select_user(user)
       }
@@ -138,13 +138,13 @@ module Pages
       add_new_role.set(new_role)
       add_role.click
     end
-  
+
     def delete_users_from_db(users)
       payload="{\"enabled\":\"false\"}"
       users.split(',').each{|user|
         RestClient.patch http_url("/api/users/#{user}"), payload,
         { content_type: :json, accept: 'application/vnd.go.cd.v3+json' }.merge(basic_configuration.header)
-      
+
         RestClient.delete http_url("/api/users/#{user}"),
         { content_type: :json, accept: 'application/vnd.go.cd.v3+json' }.merge(basic_configuration.header)
       }

--- a/specs/EditStagePermissionsWithPipelineGroupPermissions.spec
+++ b/specs/EditStagePermissionsWithPipelineGroupPermissions.spec
@@ -6,6 +6,7 @@ Setup of contexts
 * Secure Configuration - setup
 * Login as "admin" - setup
 * Using pipeline "edit-pipeline" - setup
+* Update toggle "users_page_using_rails" to value "on"
 * Capture go state "EditStagePermissionsWithPipelineGroupPermissions" - setup
 
 EditStagePermissionsWithPipelineGroupPermissions
@@ -61,4 +62,5 @@ Teardown of contexts
 ____________________
 * Delete users "user3,user4" from DB
 * Capture go state "EditStagePermissionsWithPipelineGroupPermissions" - teardown
+* Update toggle "users_page_using_rails" to value "off"
 * Logout - from any page


### PR DESCRIPTION
Previous versions of site prism was not validating the condition in load validation method which resulted in invalid validations being present and never identified. This commit fixes them