### PR TITLE
Fix for regression failure of elastic agents specs

### DIFF
--- a/lib/pages/elastic_profiles_page.rb
+++ b/lib/pages/elastic_profiles_page.rb
@@ -54,14 +54,12 @@ module Pages
       cluster_profile_header(cluster_profile_id).find("button[data-test-id='new-elastic-agent-profile-button']").click
     end
 
-    def has_selected_cluster_profile_id(cluster_profile_id, plugin_name)
-      page.all("div[data-test-id='form-field-input-cluster-profile-id']")
-          .find {|select| select.value === `#{cluster_profile_id} (#{plugin_name})`} != nil
+    def has_selected_cluster_profile_id?(cluster_profile_id, plugin_name)
+      page.has_css?("[data-test-id='form-field-input-cluster-profile-id']", text: "#{cluster_profile_id} (#{plugin_name})")
     end
 
-    def has_elastic_agent(elastic_agent_profile_id)
-      page.all("div[data-test-id='elastic_profile_id']")
-          .find {|div| div.text === elastic_agent_profile_id} != nil
+    def has_elastic_agent?(elastic_agent_profile_id)
+      page.has_css?("[data-test-id='elastic_profile_id']", text: elastic_agent_profile_id)
     end
 
     def edit_cluster_profile(cluster_profile_id)
@@ -92,7 +90,8 @@ module Pages
     end
 
     def expand_cluster_profile_header(cluster_profile_id)
-      cluster_profile_header(cluster_profile_id).click
+      cluster_panel = cluster_profile_header(cluster_profile_id)
+      cluster_panel.find("[data-test-id='plugin-icon']").click if cluster_panel[:'data-test-element-state'].eql? "collapsed"
     end
 
     def cluster_profiles_exists?(cluster_profile)

--- a/specs/ElasticAgentProfilesCRUDOperations.spec
+++ b/specs/ElasticAgentProfilesCRUDOperations.spec
@@ -26,6 +26,7 @@ Note: This spec will use 2 elastic agent(Docker and K8s plguins) plugins and set
 
 * Clone Elastic agent profile "Profile-Using-Docker-Cluster" of cluster "Docker-Cluster" by name "Cloned-Docker"
 
+* Expand cluster profile "Docker-Cluster"
 * Verify elastic agent profiles "Profile-Using-Docker-Cluster, Cloned-Docker" listed
 
 * On Elastic profiles page
@@ -37,7 +38,8 @@ Note: This spec will use 2 elastic agent(Docker and K8s plguins) plugins and set
 * Set docker image as "rajiesh/gocd-agent-centos-7-test:v19.2.0"
 * Save elastic agent profile
 
-* Verify elastic agent profile "Profile-Using-Docker-Cluster" listed
+* Expand cluster profile "K8s-Cluster"
+* Verify elastic agent profiles "Profile-Using-K8s-Cluster" listed
 
 * Edit elastic agent profile "Profile-Using-K8s-Cluster" of cluster profile "K8s-Cluster"
 * Set maximum memory limit as "100"
@@ -48,7 +50,8 @@ Note: This spec will use 2 elastic agent(Docker and K8s plguins) plugins and set
 * Verify "MaxMemory" is "100M" for elastic agent profile "Profile-Using-K8s-Cluster" - Using elastic agent profile API
 
 * Delete elastic agent profile "Profile-Using-Docker-Cluster" of cluster "Docker-Cluster"
-* Verify elastic agent profile "Cloned-Docker" listed
+* Expand cluster profile "Docker-Cluster"
+* Verify elastic agent profiles "Cloned-Docker" listed
 
 * Verify "2" elastic agent profiles "Cloned-Docker, Profile-Using-K8s-Cluster" are only returned  - Using get all elastic agent profile API
 

--- a/specs/ElasticProfiles.spec
+++ b/specs/ElasticProfiles.spec
@@ -32,7 +32,8 @@ tags: elastic_agent_profile
 * Set docker image as "rajiesh/gocd-agent-centos-7-test:v19.2.0"
 * Save the elastic agent profile
 
-* Verify elastic agent profile "Profile-Using-Cluster-1" listed
+* Expand cluster profile "Cluster-1"
+* Verify elastic agent profiles "Profile-Using-Cluster-1" listed
 
 * Update pipeline "pipeline-with-elastic-agent-profile-1" stage "defaultStage" job "defaultJob" with elastic profile id "Profile-Using-Cluster-1" - Using pipeline config API
 
@@ -78,7 +79,8 @@ tags: elastic_agent_profile
 * Set docker image as "rajiesh/gocd-agent-centos-7-test:v19.2.0"
 * Save the elastic agent profile
 
-* Verify elastic agent profile "Profile-Using-Cluster-2" listed
+* Expand cluster profile "Cluster-2"
+* Verify elastic agent profiles "Profile-Using-Cluster-2" listed
 
 * Update pipeline "pipeline-with-elastic-agent-profile-2" stage "defaultStage" job "defaultJob" with elastic profile id "Profile-Using-Cluster-2" - Using pipeline config API
 

--- a/step_implementations/specs/elastic_profiles_spec.rb
+++ b/step_implementations/specs/elastic_profiles_spec.rb
@@ -50,6 +50,10 @@ step 'Set docker URI as <docker_uri> for cluster profile' do |docker_uri|
   elastic_profiles_page.docker_uri.set docker_uri
 end
 
+step 'Expand cluster profile <id>' do |id|
+  elastic_profiles_page.expand_cluster_profile_header(id)
+end
+
 step 'Save cluster profile' do
   elastic_profiles_page.save_cluster_profile
 end
@@ -63,7 +67,7 @@ step 'Set agent profile name as <elastic_agent_profile_name>' do |elastic_agent_
 end
 
 step 'Check cluster id is selected as <cluster_profile_id> with plugin <plugin_name>' do |cluster_profile_id, plugin_name|
-  elastic_profiles_page.has_selected_cluster_profile_id(cluster_profile_id, plugin_name)
+  assert_true elastic_profiles_page.has_selected_cluster_profile_id?(cluster_profile_id, plugin_name)
 end
 
 step 'Set docker image as <image>' do |image|
@@ -72,10 +76,6 @@ end
 
 step 'Save elastic agent profile' do
   elastic_profiles_page.save_elastic_agent_profile
-end
-
-step 'Verify elastic agent profile <elastic_agent_profile_id> listed' do |elastic_agent_profile_id|
-  elastic_profiles_page.has_elastic_agent(elastic_agent_profile_id)
 end
 
 step 'Edit cluster profile <cluster_profile_id>' do |cluster_profile_id|
@@ -112,7 +112,6 @@ step 'Clusters <cluster_profiles> should be listed on the SPA' do |cluster_profi
 end
 
 step 'Edit elastic agent profile <elastic_agent_profile_id> of cluster profile <cluster_profile_id>' do |elastic_agent_profile_id, cluster_profile_id|
-  elastic_profiles_page.expand_cluster_profile_header(cluster_profile_id)
   elastic_profiles_page.edit_elastic_agent_profile(cluster_profile_id, elastic_agent_profile_id)
 end
 


### PR DESCRIPTION
While expanding the cluster profile to perform crud operations on agent profile, the expand method clicks the cluster header panel. Sometimes the status report button is getting clicked which navigates to cluster status report page instead of expanding the panel. Fixed it by clicking on the plugin icon. Fixed some missing assertions