### PR TITLE
Use —mount instead of -v while mounting volumes on container

### DIFF
--- a/lib/context/server.rb
+++ b/lib/context/server.rb
@@ -106,7 +106,7 @@ module Context
       sh %(docker load < "target/docker-server/#{manifest.file}")
       sh %(docker run -d --name gauge_server -p #{GoConstants::SERVER_PORT}:#{GoConstants::SERVER_PORT} \
         -p #{GoConstants::SERVER_SSL_PORT}:#{GoConstants::SERVER_SSL_PORT} \
-        -v #{File.expand_path(GoConstants::CONFIG_PATH.to_s)}:/test-config -v #{GoConstants::SERVER_DIR}:/godata \
+        -v #{File.expand_path(GoConstants::CONFIG_PATH.to_s)}:/test-config --mount #{GoConstants::SERVER_DIR}:/godata \
         -v #{GoConstants::TEMP_DIR}:/materials \
         -e GO_SERVER_SYSTEM_PROPERTIES='#{GoConstants::GO_SERVER_SYSTEM_PROPERTIES}' \
         -e GO_SERVER_PORT='#{GoConstants::SERVER_PORT}' \


### PR DESCRIPTION
-v will create the folder if it doesn’t exists, this gives false positive in case of EFS test as it will create the folder if mount is not present.