### PR TITLE
Azure file system test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -321,7 +321,7 @@ task :setup_azure_resources do
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
-  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
+#  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"
   sh "tee /root/.gitconfig >/dev/null <<EOF
 [core]

--- a/Rakefile
+++ b/Rakefile
@@ -316,11 +316,10 @@ end
 end
 
 task :setup_azure_resources do
-  sh "az login --service-principal --username '#{AZ_SP_USERNAME}' --password '#{AZ_SP_PASSWORD}' --tenant '#{AZ_TENANT_ID}'"
-  sh "az group deployment create --name gocdstorageaccount --resource-group '#{AZ_RESOURCE_GROUP}' --template-file resources/template.json --parameters resources/parameters.json"
-  sh "current_env_conn_string=$(az storage account show-connection-string -n '#{AZ_STORAGE_ACCOUNT_NAME}' -g '#{AZ_RESOURCE_GROUP}' --query 'connectionString' -o tsv) &&
-    az storage share create --name '#{AZ_FILE_SHARE_NAME}' --quota 4096 --connection-string $current_env_conn_string > /dev/null"
-  sh "az_storage_account_key=$(az storage account keys list -g gocd-resource-group -n '#{AZ_STORAGE_ACCOUNT_NAME}' --query "[0].value" | xargs) &&
-  sudo mount -t cifs //https://gocdsa.file.core.windows.net/gocdfs  target -o vers=3.0,username=gocdsa,password=$az_storage_account_key,dir_mode=0777,file_mode=0777,serverino"
-
+  sh "az login --service-principal --username #{AZ_SP_USERNAME} --password #{AZ_SP_PASSWORD} --tenant #{AZ_TENANT_ID}"
+  sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
+  STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv)`
+  sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string #{STORAGE_ACCOUNT_CONNECTION_STRING} > /dev/null"
+  STORAGE_ACCOUNT_KEY=`az_storage_account_key=$(az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value" | xargs)`
+  sh "sudo mount -t cifs //https://gocdsa.file.core.windows.net/gocdfs  target -o vers=3.0,username=gocdsa,password=#{STORAGE_ACCOUNT_KEY},dir_mode=0777,file_mode=0777,serverino"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -324,9 +324,6 @@ task :setup_azure_resources do
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota #{AZ_FILE_SHARE_QUOTA} --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g #{AZ_RESOURCE_GROUP} -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs /mnt/AzureFileShare -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
-  sh "touch /root/.gitconfig"
-  sh "tee /root/.gitconfig >/dev/null <<EOF
-[core]
-        supportsatomicfilecreation = true
-EOF"
+  sh 'git config --global core.supportsatomicfilecreation true'
+
 end

--- a/Rakefile
+++ b/Rakefile
@@ -331,6 +331,6 @@ end
 
 task :cleanup_azure_resources do
 
-  sh "az storage account delete -n #{AZ_STORAGE_ACCOUNT_NAME} --resource-group #{AZ_RESOURCE_GROUP}--yes"
+  sh "az storage account delete -n #{AZ_STORAGE_ACCOUNT_NAME} --resource-group #{AZ_RESOURCE_GROUP} --yes"
   sh "az group deployment delete --verbose --name #{AZ_STORAGE_DEPLOYMENT_NAME} --resource-group #{AZ_RESOURCE_GROUP}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -322,7 +322,7 @@ task :setup_azure_resources do
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
-  mkdir_p "~/.gitconfig"
+  touch "~/.gitconfig"
   sh "tee ~/.gitconfig >/dev/null <<EOF \
   [core] \
           supportsatomicfilecreation = true \

--- a/Rakefile
+++ b/Rakefile
@@ -322,7 +322,7 @@ task :setup_azure_resources do
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
-  sh "touch ~/.gitconfig"
+  sh "touch /root/.gitconfig"
   sh "tee ~/.gitconfig >/dev/null <<EOF
   [core]
           supportsatomicfilecreation = true

--- a/Rakefile
+++ b/Rakefile
@@ -323,8 +323,8 @@ task :setup_azure_resources do
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   mkdir_p "~/.gitconfig"
-  sh "tee ~/.gitconfig >/dev/null <<EOF
-  [core]
-          supportsatomicfilecreation = true
+  sh "tee ~/.gitconfig >/dev/null <<EOF \
+  [core] \
+          supportsatomicfilecreation = true \
   EOF"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ AZ_RESOURCE_GROUP        = ENV['AZ_RESOURCE_GROUP'] || 'gocd-resource-group'
 AZ_STORAGE_ACCOUNT_NAME  = ENV['AZ_STORAGE_ACCOUNT_NAME'] || 'gocdsa'
 AZ_FILE_SHARE_NAME       = ENV['AZ_FILE_SHARE_NAME'] || 'gocdfs'
 AZ_FILE_SHARE_QUOTA      = ENV['AZ_FILE_SHARE_QUOTA'] || 100
+AZ_STORAGE_DEPLOYMENT_NAME = ENV['AZ_STORAGE_DEPLOYMENT_NAME'] || gocdstorageaccount
 
 
 DOCKER_EA_PLUGIN_RELEASE_URL                = ENV['DOCKER_EA_PLUGIN_RELEASE_URL'] || 'https://api.github.com/repos/gocd-contrib/docker-elastic-agents/releases/latest'
@@ -319,11 +320,17 @@ end
 task :setup_azure_resources do
   sh "mkdir -p /mnt/AzureFileShare"
   sh "az login --service-principal --username #{AZ_SP_USERNAME} --password #{AZ_SP_PASSWORD} --tenant #{AZ_TENANT_ID}"
-  sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
+  sh "az group deployment create --name #{AZ_STORAGE_DEPLOYMENT_NAME} --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota #{AZ_FILE_SHARE_QUOTA} --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g #{AZ_RESOURCE_GROUP} -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs /mnt/AzureFileShare -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh 'git config --global core.supportsatomicfilecreation true'
 
+end
+
+task :cleanup_azure_resources do
+
+  sh "az storage account delete -n #{AZ_STORAGE_ACCOUNT_NAME} --resource-group #{AZ_RESOURCE_GROUP}--yes"
+  sh "az group deployment delete --verbose --name #{AZ_STORAGE_DEPLOYMENT_NAME} --resource-group #{AZ_RESOURCE_GROUP}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ AZ_RESOURCE_GROUP        = ENV['AZ_RESOURCE_GROUP'] || 'gocd-resource-group'
 AZ_STORAGE_ACCOUNT_NAME  = ENV['AZ_STORAGE_ACCOUNT_NAME'] || 'gocdsa'
 AZ_FILE_SHARE_NAME       = ENV['AZ_FILE_SHARE_NAME'] || 'gocdfs'
 AZ_FILE_SHARE_QUOTA      = ENV['AZ_FILE_SHARE_QUOTA'] || 100
-AZ_STORAGE_DEPLOYMENT_NAME = ENV['AZ_STORAGE_DEPLOYMENT_NAME'] || gocdstorageaccount
+AZ_STORAGE_DEPLOYMENT_NAME = ENV['AZ_STORAGE_DEPLOYMENT_NAME'] || 'gocdstorageaccount'
 
 
 DOCKER_EA_PLUGIN_RELEASE_URL                = ENV['DOCKER_EA_PLUGIN_RELEASE_URL'] || 'https://api.github.com/repos/gocd-contrib/docker-elastic-agents/releases/latest'

--- a/Rakefile
+++ b/Rakefile
@@ -322,7 +322,7 @@ task :setup_azure_resources do
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
-  touch "~/.gitconfig"
+  sh "touch ~/.gitconfig"
   sh "tee ~/.gitconfig >/dev/null <<EOF
   [core]
           supportsatomicfilecreation = true

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,8 @@ AZ_SP_PASSWORD           = ENV['AZ_SP_PASSWORD']
 AZ_TENANT_ID             = ENV['AZ_TENANT_ID']
 AZ_RESOURCE_GROUP        = ENV['AZ_RESOURCE_GROUP'] || 'gocd-resource-group'
 AZ_STORAGE_ACCOUNT_NAME  = ENV['AZ_STORAGE_ACCOUNT_NAME'] || 'gocdsa'
-AZ_FILE_SHARE_NAME       = ENV['AZ_FILE_SHARE_NAME'] || 'gocdfs'  
+AZ_FILE_SHARE_NAME       = ENV['AZ_FILE_SHARE_NAME'] || 'gocdfs'
+AZ_FILE_SHARE_QUOTA      = ENV['AZ_FILE_SHARE_QUOTA'] || 100
 
 
 DOCKER_EA_PLUGIN_RELEASE_URL                = ENV['DOCKER_EA_PLUGIN_RELEASE_URL'] || 'https://api.github.com/repos/gocd-contrib/docker-elastic-agents/releases/latest'
@@ -319,7 +320,7 @@ task :setup_azure_resources do
   sh "az login --service-principal --username #{AZ_SP_USERNAME} --password #{AZ_SP_PASSWORD} --tenant #{AZ_TENANT_ID}"
   sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
-  sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
+  sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota #{AZ_FILE_SHARE_QUOTA} --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g #{AZ_RESOURCE_GROUP} -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"

--- a/Rakefile
+++ b/Rakefile
@@ -321,7 +321,7 @@ task :setup_azure_resources do
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g #{AZ_RESOURCE_GROUP} -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
-#  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
+  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"
   sh "tee /root/.gitconfig >/dev/null <<EOF
 [core]

--- a/Rakefile
+++ b/Rakefile
@@ -324,7 +324,7 @@ task :setup_azure_resources do
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"
   sh "tee /root/.gitconfig >/dev/null <<EOF
-  [core]
-          supportsatomicfilecreation = true
-  EOF"
+[core]
+        supportsatomicfilecreation = true
+EOF"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -323,7 +323,7 @@ task :setup_azure_resources do
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"
-  sh "tee ~/.gitconfig >/dev/null <<EOF
+  sh "tee /root/.gitconfig >/dev/null <<EOF
   [core]
           supportsatomicfilecreation = true
   EOF"

--- a/Rakefile
+++ b/Rakefile
@@ -320,7 +320,7 @@ task :setup_azure_resources do
   sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
-  STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
+  STORAGE_ACCOUNT_KEY=`az storage account keys list -g #{AZ_RESOURCE_GROUP} -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
 #  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"
   sh "tee /root/.gitconfig >/dev/null <<EOF

--- a/Rakefile
+++ b/Rakefile
@@ -318,8 +318,8 @@ end
 task :setup_azure_resources do
   sh "az login --service-principal --username #{AZ_SP_USERNAME} --password #{AZ_SP_PASSWORD} --tenant #{AZ_TENANT_ID}"
   sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
-  STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv)`
-  sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string #{STORAGE_ACCOUNT_CONNECTION_STRING} > /dev/null"
-  STORAGE_ACCOUNT_KEY=`az_storage_account_key=$(az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value" | xargs)`
-  sh "sudo mount -t cifs //https://gocdsa.file.core.windows.net/gocdfs  target -o vers=3.0,username=gocdsa,password=#{STORAGE_ACCOUNT_KEY},dir_mode=0777,file_mode=0777,serverino"
+  STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
+  sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
+  STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value" | xargs`
+  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY},dir_mode=0777,file_mode=0777,serverino"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -320,6 +320,6 @@ task :setup_azure_resources do
   sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
-  STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value" | xargs`
-  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY},dir_mode=0777,file_mode=0777,serverino"
+  STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
+  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -323,8 +323,8 @@ task :setup_azure_resources do
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   touch "~/.gitconfig"
-  sh "tee ~/.gitconfig >/dev/null <<EOF \
-  [core] \
-          supportsatomicfilecreation = true \
+  sh "tee ~/.gitconfig >/dev/null <<EOF
+  [core]
+          supportsatomicfilecreation = true
   EOF"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -322,8 +322,9 @@ task :setup_azure_resources do
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
-  sh "tee ~/.gitconfig >/dev/null <<EOF \
-  [core] \
-          supportsatomicfilecreation = true\
+  mkdir_p "~/.gitconfig"
+  sh "tee ~/.gitconfig >/dev/null <<EOF
+  [core]
+          supportsatomicfilecreation = true
   EOF"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -39,9 +39,9 @@ USE_POSTGRESQL   = !ENV['USE_POSTGRESQL'].nil?
 AZ_SP_USERNAME           = ENV['AZ_SP_USERNAME']
 AZ_SP_PASSWORD           = ENV['AZ_SP_PASSWORD']
 AZ_TENANT_ID             = ENV['AZ_TENANT_ID']
-AZ_RESOURCE_GROUP        = ENV['AZ_RESOURCE_GROUP']
+AZ_RESOURCE_GROUP        = ENV['AZ_RESOURCE_GROUP'] || 'gocd-resource-group'
 AZ_STORAGE_ACCOUNT_NAME  = ENV['AZ_STORAGE_ACCOUNT_NAME'] || 'gocdsa'
-AZ_FILE_SHARE_NAME       = ENV['AZ_FILE_SHARE_NAME'] || 'gocdfs'
+AZ_FILE_SHARE_NAME       = ENV['AZ_FILE_SHARE_NAME'] || 'gocdfs'  
 
 
 DOCKER_EA_PLUGIN_RELEASE_URL                = ENV['DOCKER_EA_PLUGIN_RELEASE_URL'] || 'https://api.github.com/repos/gocd-contrib/docker-elastic-agents/releases/latest'

--- a/Rakefile
+++ b/Rakefile
@@ -322,4 +322,8 @@ task :setup_azure_resources do
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota 4096 --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g gocd-resource-group -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
   sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
+  sh "tee ~/.gitconfig >/dev/null <<EOF \
+  [core] \
+          supportsatomicfilecreation = true\
+  EOF"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -317,12 +317,13 @@ end
 end
 
 task :setup_azure_resources do
+  sh "mkdir -p /mnt/AzureFileShare"
   sh "az login --service-principal --username #{AZ_SP_USERNAME} --password #{AZ_SP_PASSWORD} --tenant #{AZ_TENANT_ID}"
   sh "az group deployment create --name gocdstorageaccount --resource-group #{AZ_RESOURCE_GROUP} --template-file resources/template.json --parameters resources/parameters.json"
   STORAGE_ACCOUNT_CONNECTION_STRING=`az storage account show-connection-string -n #{AZ_STORAGE_ACCOUNT_NAME} -g #{AZ_RESOURCE_GROUP} --query 'connectionString' -o tsv`
   sh "az storage share create --name #{AZ_FILE_SHARE_NAME} --quota #{AZ_FILE_SHARE_QUOTA} --connection-string '#{STORAGE_ACCOUNT_CONNECTION_STRING}'"
   STORAGE_ACCOUNT_KEY=`az storage account keys list -g #{AZ_RESOURCE_GROUP} -n #{AZ_STORAGE_ACCOUNT_NAME} --query "[0].value"`
-  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs  target -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
+  sh "mount -t cifs //#{AZ_STORAGE_ACCOUNT_NAME}.file.core.windows.net/gocdfs /mnt/AzureFileShare -o vers=3.0,dir_mode=0777,file_mode=0777,serverino,username=#{AZ_STORAGE_ACCOUNT_NAME},password=#{STORAGE_ACCOUNT_KEY}"
   sh "touch /root/.gitconfig"
   sh "tee /root/.gitconfig >/dev/null <<EOF
 [core]

--- a/lib/context/server.rb
+++ b/lib/context/server.rb
@@ -109,6 +109,7 @@ module Context
       sh %(docker run -d --name gauge_server -p #{GoConstants::SERVER_PORT}:#{GoConstants::SERVER_PORT} \
         -p #{GoConstants::SERVER_SSL_PORT}:#{GoConstants::SERVER_SSL_PORT} \
         -v #{File.expand_path(GoConstants::CONFIG_PATH.to_s)}:/test-config --mount type=bind,source=#{GoConstants::SERVER_DIR},target=/godata \
+        -v /root/.gitconfig:/home/go/.gitconfig \
         -v #{GoConstants::TEMP_DIR}:/materials \
         -e GOCD_SERVER_JVM_OPTS='#{GoConstants::GO_SERVER_SYSTEM_PROPERTIES.join(" ")}' \
         #{image.image}:#{image.tag})

--- a/lib/context/server.rb
+++ b/lib/context/server.rb
@@ -107,6 +107,8 @@ module Context
       image = server_image_to_use
       sh %(docker load < "target/docker-server/#{image.file}")
 
+      # The if-else block is added to accomodate the mount of .gitconfig. This is needed to avoid a bug with jgit where it does not by default support atomic link creation
+      
       if ENV['USE_AFS']
         sh %(docker run -d --name gauge_server -p #{GoConstants::SERVER_PORT}:#{GoConstants::SERVER_PORT} \
           -p #{GoConstants::SERVER_SSL_PORT}:#{GoConstants::SERVER_SSL_PORT} \

--- a/lib/context/server.rb
+++ b/lib/context/server.rb
@@ -106,15 +106,26 @@ module Context
     def run_server_on_docker
       image = server_image_to_use
       sh %(docker load < "target/docker-server/#{image.file}")
-      sh %(docker run -d --name gauge_server -p #{GoConstants::SERVER_PORT}:#{GoConstants::SERVER_PORT} \
-        -p #{GoConstants::SERVER_SSL_PORT}:#{GoConstants::SERVER_SSL_PORT} \
-        -v #{File.expand_path(GoConstants::CONFIG_PATH.to_s)}:/test-config --mount type=bind,source=#{GoConstants::SERVER_DIR},target=/godata \
-        -v /root/.gitconfig:/home/go/.gitconfig \
-        -v #{GoConstants::TEMP_DIR}:/materials \
-        -e GOCD_SERVER_JVM_OPTS='#{GoConstants::GO_SERVER_SYSTEM_PROPERTIES.join(" ")}' \
-        #{image.image}:#{image.tag})
+
+      if ENV['USE_AFS']
+        sh %(docker run -d --name gauge_server -p #{GoConstants::SERVER_PORT}:#{GoConstants::SERVER_PORT} \
+          -p #{GoConstants::SERVER_SSL_PORT}:#{GoConstants::SERVER_SSL_PORT} \
+          -v #{File.expand_path(GoConstants::CONFIG_PATH.to_s)}:/test-config --mount type=bind,source=#{GoConstants::SERVER_DIR},target=/godata \
+          -v /root/.gitconfig:/home/go/.gitconfig \
+          -v #{GoConstants::TEMP_DIR}:/materials \
+          -e GOCD_SERVER_JVM_OPTS='#{GoConstants::GO_SERVER_SYSTEM_PROPERTIES.join(" ")}' \
+          #{image.image}:#{image.tag})
+      else
+        sh %(docker run -d --name gauge_server -p #{GoConstants::SERVER_PORT}:#{GoConstants::SERVER_PORT} \
+          -p #{GoConstants::SERVER_SSL_PORT}:#{GoConstants::SERVER_SSL_PORT} \
+          -v #{File.expand_path(GoConstants::CONFIG_PATH.to_s)}:/test-config --mount type=bind,source=#{GoConstants::SERVER_DIR},target=/godata \
+          -v #{GoConstants::TEMP_DIR}:/materials \
+          -e GOCD_SERVER_JVM_OPTS='#{GoConstants::GO_SERVER_SYSTEM_PROPERTIES.join(" ")}' \
+          #{image.image}:#{image.tag})
+      end
       # This is done to save space on the EA container
       sh %(rm -rf target/docker-server)
+
     end
 
     def server_image_to_use

--- a/resources/parameters.json
+++ b/resources/parameters.json
@@ -9,13 +9,10 @@
             "value": "gocdsa"
         },
         "accountType": {
-            "value": "Standard_RAGRS"
+            "value": "Premium_LRS"
         },
         "kind": {
-            "value": "StorageV2"
-        },
-        "accessTier": {
-            "value": "Hot"
+            "value": "FileStorage"
         },
         "supportsHttpsTrafficOnly": {
             "value": true

--- a/resources/parameters.json
+++ b/resources/parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "value": "centralus"
+        },
+        "storageAccountName": {
+            "value": "gocdsa"
+        },
+        "accountType": {
+            "value": "Standard_RAGRS"
+        },
+        "kind": {
+            "value": "StorageV2"
+        },
+        "accessTier": {
+            "value": "Hot"
+        },
+        "supportsHttpsTrafficOnly": {
+            "value": true
+        }
+    }
+}

--- a/resources/parameters.json
+++ b/resources/parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "location": {
-            "value": "centralus"
+            "value": "eastus"
         },
         "storageAccountName": {
             "value": "gocdsa"

--- a/resources/template.json
+++ b/resources/template.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string"
+        },
+        "storageAccountName": {
+            "type": "string"
+        },
+        "accountType": {
+            "type": "string"
+        },
+        "kind": {
+            "type": "string"
+        },
+        "accessTier": {
+            "type": "string"
+        },
+        "supportsHttpsTrafficOnly": {
+            "type": "bool"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "name": "[parameters('storageAccountName')]",
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2019-04-01",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accessTier": "[parameters('accessTier')]",
+                "supportsHttpsTrafficOnly": "[parameters('supportsHttpsTrafficOnly')]"
+            },
+            "dependsOn": [],
+            "sku": {
+                "name": "[parameters('accountType')]"
+            },
+            "kind": "[parameters('kind')]"
+        }
+    ],
+    "outputs": {}
+}

--- a/resources/template.json
+++ b/resources/template.json
@@ -14,9 +14,6 @@
         "kind": {
             "type": "string"
         },
-        "accessTier": {
-            "type": "string"
-        },
         "supportsHttpsTrafficOnly": {
             "type": "bool"
         }
@@ -29,7 +26,6 @@
             "apiVersion": "2019-04-01",
             "location": "[parameters('location')]",
             "properties": {
-                "accessTier": "[parameters('accessTier')]",
                 "supportsHttpsTrafficOnly": "[parameters('supportsHttpsTrafficOnly')]"
             },
             "dependsOn": [],

--- a/step_implementations/go_constants.rb
+++ b/step_implementations/go_constants.rb
@@ -25,12 +25,15 @@ class GoConstants
   RUN_ON_DOCKER = ENV['RUN_ON_DOCKER']
   USE_EFS = ENV['USE_EFS']
   USE_GCP_FILESTORE = ENV['USE_GCP_FILESTORE']
+  USE_AFS = ENV['USE_AFS']
   SERVER_DIR = if USE_EFS
                  '/efs'
                elsif USE_GCP_FILESTORE
                  '/filestore'
                elsif RUN_ON_DOCKER
                  File.expand_path('godata')
+               elsif USE_AFS
+                 File.expand_path('/mnt/AzureFileShare')
                else
                  Dir["target/go-server-#{GO_VERSION}"].find { |f| File.directory?(f) }
                end

--- a/step_implementations/go_constants.rb
+++ b/step_implementations/go_constants.rb
@@ -30,10 +30,10 @@ class GoConstants
                  '/efs'
                elsif USE_GCP_FILESTORE
                  '/filestore'
+               elsif USE_AFS
+                 '/mnt/AzureFileShare'
                elsif RUN_ON_DOCKER
                  File.expand_path('godata')
-               elsif USE_AFS
-                 File.expand_path('/mnt/AzureFileShare')
                else
                  Dir["target/go-server-#{GO_VERSION}"].find { |f| File.directory?(f) }
                end

--- a/step_implementations/initialize.rb
+++ b/step_implementations/initialize.rb
@@ -45,13 +45,13 @@ Gauge.configure do |config|
   config.include Helpers::SpecHelper
   config.include Helpers::GoUrlHelper
   config.include Helpers::Wait
-  config.screengrabber = -> {
+#  config.screengrabber = -> {
 #    Capybara.page.save_screenshot
 #    file = File.open(Dir.glob('screenshots/*.png').first, 'rb')
 #    file_content = File.binread(file.path)
 #    #FileUtils.rm_r 'screenshots', force: true
 #    return file_content
- }
+# }
 end
 
 Capybara.configure do |config|

--- a/step_implementations/initialize.rb
+++ b/step_implementations/initialize.rb
@@ -46,12 +46,12 @@ Gauge.configure do |config|
   config.include Helpers::GoUrlHelper
   config.include Helpers::Wait
   config.screengrabber = -> {
-    Capybara.page.save_screenshot
-    file = File.open(Dir.glob('screenshots/*.png').first, 'rb')
-    file_content = File.binread(file.path)
-    #FileUtils.rm_r 'screenshots', force: true
-    return file_content
-  }
+#    Capybara.page.save_screenshot
+#    file = File.open(Dir.glob('screenshots/*.png').first, 'rb')
+#    file_content = File.binread(file.path)
+#    #FileUtils.rm_r 'screenshots', force: true
+#    return file_content
+ }
 end
 
 Capybara.configure do |config|

--- a/step_implementations/initialize.rb
+++ b/step_implementations/initialize.rb
@@ -45,13 +45,13 @@ Gauge.configure do |config|
   config.include Helpers::SpecHelper
   config.include Helpers::GoUrlHelper
   config.include Helpers::Wait
-#  config.screengrabber = -> {
-#    Capybara.page.save_screenshot
-#    file = File.open(Dir.glob('screenshots/*.png').first, 'rb')
-#    file_content = File.binread(file.path)
-#    #FileUtils.rm_r 'screenshots', force: true
-#    return file_content
-# }
+  config.screengrabber = -> {
+    Capybara.page.save_screenshot
+    file = File.open(Dir.glob('screenshots/*.png').first, 'rb')
+    file_content = File.binread(file.path)
+    #FileUtils.rm_r 'screenshots', force: true
+    return file_content
+ }
 end
 
 Capybara.configure do |config|


### PR DESCRIPTION
Added tests for running smoke on azure file system.

Setup:

1. We use an Azure EA to spin a VM on azure cloud.
2. Create a Premium Storage account in build-gocd resource group.
3. Create a file share in the storage account. File shares follow SMB protocol.
4. Mount the file share on a path "mnt/AzureFileShare" on the Azure VM using CIFS tools.
5. Service Prinicpal is used to authenticate the all create/delete/mount calls. Service Principal is stored in team 1Password as : Azure File System Service Principal

Test:

The test brings up a docker agent with two distinct mount points 

1. /mnt/AzureFileShare:/godata: This is to ensure we use Azure File share for storage.
2. /root/.gitconfig:/home/go/.gitconfig: This is to mitigate the jgit bug which by default does not set the supportsatomicfilecreation flag to true.

We use xvfb-run to emulate a display for the tests.





