### PR TITLE
Fixes for config xml migration 132 -

### DIFF
--- a/resources/config/auth-plugins-config.xml
+++ b/resources/config/auth-plugins-config.xml
@@ -15,8 +15,12 @@
  * limitations under the License.
  *************************GO-LICENSE-END******************************* -->
 
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd"
+        schemaVersion="132">
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
         <security>
           <authConfigs>
               <authConfig id="61f10215-9fba-4962-a2f4-d6c8944ade32" pluginId="cd.go.authentication.passwordfile">

--- a/resources/config/basic-cruise-config.xml
+++ b/resources/config/basic-cruise-config.xml
@@ -16,7 +16,11 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token"/>
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
+    </server>
     <pipelines group="basic">
     <pipeline name="basic-pipeline-fast-with-job-properties">
             <materials>

--- a/resources/config/basic-secure-cruise-config.xml
+++ b/resources/config/basic-secure-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" agentAutoRegisterKey="functional-tests" tokenGenerationKey="token">
+    <server commandRepositoryLocation="default" serverId="gauge" agentAutoRegisterKey="functional-tests" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
         <security>
           <authConfigs>
               <authConfig id="61f10215-9fba-4962-a2f4-d6c8944ade32" pluginId="cd.go.authentication.passwordfile">

--- a/resources/config/basic-single-pipeline-config.xml
+++ b/resources/config/basic-single-pipeline-config.xml
@@ -16,7 +16,11 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token"/>
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
+    </server>
     <pipelines group="defaultGroup">
         <pipeline name="basic-pipeline-run-and-cancel">
             <materials>

--- a/resources/config/conflict-cruise-config-for-pipelineAdmin.xml
+++ b/resources/config/conflict-cruise-config-for-pipelineAdmin.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-  <server artifactsdir="logs" commandRepositoryLocation="default" serverId="dev-id" tokenGenerationKey="token">
+  <server commandRepositoryLocation="default" serverId="dev-id" tokenGenerationKey="token">
+      <artifacts>
+          <artifactsDir>logs</artifactsDir>
+      </artifacts>
       <security>
 
       <roles>

--- a/resources/config/conflict-cruise-config.xml
+++ b/resources/config/conflict-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-  <server artifactsdir="artifacts" serverId="twist" tokenGenerationKey="token">
+  <server serverId="twist" tokenGenerationKey="token">
+    <artifacts>
+      <artifactsDir>artifacts</artifactsDir>
+    </artifacts>
     <security>
       <roles>
         <role name="admins">

--- a/resources/config/external-artifacts-cruise-config.xml
+++ b/resources/config/external-artifacts-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
         <security>
           <authConfigs>
               <authConfig id="61f10215-9fba-4962-a2f4-d6c8944ade32" pluginId="cd.go.authentication.passwordfile">

--- a/resources/config/fanin-cruise-config.xml
+++ b/resources/config/fanin-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" serverId="twist" tokenGenerationKey="token">
+    <server serverId="twist" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
     </server>
 
      <!-- group 1-->

--- a/resources/config/group-admin-security-config.xml
+++ b/resources/config/group-admin-security-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-  <server artifactsdir="artifacts" serverId="gauge" tokenGenerationKey="token">
+  <server serverId="gauge" tokenGenerationKey="token">
+	  <artifacts>
+		  <artifactsDir>artifacts</artifactsDir>
+	  </artifacts>
       <security>
 
       <roles>

--- a/resources/config/invalid-cruise-config.xml
+++ b/resources/config/invalid-cruise-config.xml
@@ -16,7 +16,11 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-  <server artifactsdir="artifacts" serverId="twist" tokenGenerationKey="token">
+  <server serverId="twist" tokenGenerationKey="token">
+    <artifacts>
+      <artifactsDir>artifacts</artifactsDir>
+    </artifacts>
+  </server>
   <pipelines group="basic">
     <pipeline name="svn-pipeline">
       <materials>

--- a/resources/config/multiple-agents-cruise-config.xml
+++ b/resources/config/multiple-agents-cruise-config.xml
@@ -16,7 +16,11 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token"/>
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
+    </server>
     <environments>
 	<environment name="Prod">
 	      <agents>

--- a/resources/config/permissions-cruise-config.xml
+++ b/resources/config/permissions-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-  <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="twist" tokenGenerationKey="token">
+  <server commandRepositoryLocation="default" serverId="twist" tokenGenerationKey="token">
+    <artifacts>
+      <artifactsDir>artifacts</artifactsDir>
+    </artifacts>
  <security>
 
       <roles>

--- a/resources/config/secure-cruise-config.xml
+++ b/resources/config/secure-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+        <artifacts>
+            <artifactsDir>artifacts</artifactsDir>
+        </artifacts>
         <security>
           <authConfigs>
               <authConfig id="61f10215-9fba-4962-a2f4-d6c8944ade32" pluginId="cd.go.authentication.passwordfile">

--- a/resources/config/template-admin-cruise-config.xml
+++ b/resources/config/template-admin-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-  <server artifactsdir="artifacts" serverId="twist" tokenGenerationKey="token">
+  <server serverId="twist" tokenGenerationKey="token">
+	  <artifacts>
+		  <artifactsDir>artifacts</artifactsDir>
+	  </artifacts>
       <security>
 
       <roles>

--- a/resources/config/tfs-cruise-config.xml
+++ b/resources/config/tfs-cruise-config.xml
@@ -16,7 +16,10 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" serverId="twist" tokenGenerationKey="token">
+    <server serverId="twist" tokenGenerationKey="token">
+		<artifacts>
+			<artifactsDir>artifacts</artifactsDir>
+		</artifacts>
     </server>
     <pipelines group="basic">
 		<pipeline name="tfs_artifact_in_child_directory">

--- a/resources/config/with-config-repo-cruise-config.xml
+++ b/resources/config/with-config-repo-cruise-config.xml
@@ -16,7 +16,11 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token"/>
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+       <artifacts>
+         <artifactsDir>artifacts</artifactsDir>
+       </artifacts>
+    </server>
     <config-repos>
        <config-repo id="config-repo" pluginId="json.config.plugin">
          <git url="material-for-pipeline-git-config-repo" />

--- a/resources/config/with-environments-cruise-config.xml
+++ b/resources/config/with-environments-cruise-config.xml
@@ -16,7 +16,11 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="132">
-    <server artifactsdir="artifacts" commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token"/>
+    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+      <artifacts>
+        <artifactsDir>artifacts</artifactsDir>
+      </artifacts>
+    </server>
     <pipelines group="basic">
 
     <pipeline name="environment-pipeline">


### PR DESCRIPTION
  - Remove `artifactDir` from server attribute.
  - Add `artifacts` as a config subtag in the server tag.