### PR TITLE
Update server image os to test as centos-8

### DIFF
--- a/lib/context/server.rb
+++ b/lib/context/server.rb
@@ -138,7 +138,7 @@ module Context
         image_index = ENV['GO_JOB_RUN_INDEX'] ? ENV['GO_JOB_RUN_INDEX'].to_i - 1 : 0
         manifest.image_info_at(image_index)
       else
-        manifest.image_info_of('centos-7')
+        manifest.image_info_of('centos-8')
       end
       manifest
     end


### PR DESCRIPTION
Since this commit - https://github.com/gocd/gocd/commit/47ecfb070c91932c005445868e5f4f2f55296e99 - centos-7 image of GoCD server is not created