### PR TITLE
Allow defaulting group permissions to deny if no group auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,165 @@
-[![Gauge
-Badge](https://cdn.rawgit.com/getgauge/getgauge.github.io/master/Gauge_Badge.svg)](http://getgauge.io)
+[![Gauge Badge](https://cdn.rawgit.com/getgauge/getgauge.github.io/master/Gauge_Badge.svg)](https://gauge.org)
 
 ## Pre-Requisites(with versions tested on)
-* Java 8
-* Ruby >= 2.3.3
-* Rake 12.0.0
-* Bundler 1.14.6
-* [Node](https://nodejs.org/en/) v6.10.1
-* [Gauge](http://getgauge.io) 0.9.6
-* Gauge-ruby plugin 0.4.2
-* Firefox >= 45.0
-* geckodriver 0.19.1
+
+* Java 12
+
+* Ruby 2.6.5
+
+* Rake 12.3.2
+
+* Bundler 1.17.2
+
+* [Node](https://nodejs.org/en/) v13.8.0
+
+* [Gauge](https://gauge.org/index.html) 1.0.8
+
+* gauge-ruby plugin (depends on the version of gauge used):
+
+  For gauge version 1.0.3: Make sure gauge-ruby is at 0.5.2.
+  For gauge version 1.0.8: Make sure gauge-ruby is at 0.5.3.
+
+  You might have to run `bundle update` to get the right version. Look inside `vendor/bundle` to find the correct, installed version and don't depend on the output of `gauge --version`.
+
+* Firefox >= 45.0 (verified with Firefox 75.0)
+
+* geckodriver 0.26.0
+
 * jq
 
+* wget
+
 ## Setup
-* ``` git clone``` as a sibling directory to
-  [go.cd](https://github.com/gocd/gocd) and [go-plugins](https://github.com/gocd/go-plugins)
-* ```$ cd ruby-functional-tests```
-* ```$ gauge --install-all```
+
+```
+# Make sure these are sibling directories.
+git clone https://github.com/gocd/ruby-functional-tests ruby-functional-tests
+git clone https://github.com/gocd/gocd gocd
+git clone https://github.com/gocd/go-plugins go-plugins
+
+cd ruby-functional-tests
+gauge install
+```
 
 ## Prepare and run specs
 
-* Build GoCD server and agent zip installers - cd to ```gocd``` and run: ```./gradlew clean installers:agentGenericZip installers:serverGenericZip test:test-addon:assemble```
-* Build GoCD plugins api - cd to ```gocd``` and run :
-```./gradlew -PfastBuild --parallel --max-workers 2 plugin-infra:go-plugin-api:install plugin-infra:go-plugin-api-internal:install installers:versionFile```
-* Build go plugins - cd to ```go-plugins``` and run: ```./gradlew clean assemble copyJarsToOnePlace -PgoVersion=$(jq '.go_full_version' -r ../gocd/installers/target/distributions/meta/version.json)```
-* cd to ```ruby-functional-tests``` and run : ```$ bundle install --path=vendor/bundle```
-* To clean, prepare server and agent for functional test execute this command ```bundle exec rake GO_VERSION='X.x.x' clean_test server:prepare agent:prepare```
-* To run all specs execute this command ```bundle exec rake GO_VERSION='X.x.x' GAUGE_TAGS='<spec tags to run>' test```
-* To run specific task(s), execute this command ```bundle exec rake [kill/clean/prepare/test/bump-schema] GO_VERSION='X.x.x' GAUGE_TAGS='<spec tags to run>'```
+1. Build GoCD server and agent zip installers:
+
+    ```
+    cd gocd
+    ./gradlew clean installers:agentGenericZip installers:serverGenericZip test:test-addon:assemble
+    ```
+
+2. Build GoCD plugins API library:
+
+    ```
+    cd gocd
+    ./gradlew -PfastBuild --parallel --max-workers 2 plugin-infra:go-plugin-api:install plugin-infra:go-plugin-api-internal:install installers:versionFile
+    ```
+
+3. Build GoCD plugins:
+
+    ```
+    cd go-plugins
+    ./gradlew clean assemble copyJarsToOnePlace -PgoVersion=$(jq '.go_full_version' -r ../gocd/installers/target/distributions/meta/version.json)
+    ```
+
+4. Install Ruby gems for functional tests:
+
+    ```
+    cd ruby-functional-tests
+    bundle install --path=vendor/bundle
+    ```
+
+5. Clean and prepare server and agent for functional tests:
+
+    ```
+    cd ruby-functional-tests
+    bundle exec rake GO_VERSION='X.x.x' clean_test server:prepare agent:prepare
+    ```
+
+    You can find the right version to use for `GO_VERSION` by checking the zip installers created in step 1 above, in: `gocd/installers/target/distributions/zip`. If the installer created is: `go-server-20.4.0-11553.zip`, then `GO_VERSION` should be set to `20.4.0`.
+
+6. To run all specs:
+
+    ```
+    cd ruby-functional-tests
+    bundle exec rake GO_VERSION='X.x.x' GAUGE_TAGS='<spec tags to run>' test
+    ```
+
+7. To run specific task(s), execute this command
+
+    ```
+    cd ruby-functional-tests
+    bundle exec rake [kill/clean/prepare/test/bump-schema] GO_VERSION='X.x.x' GAUGE_TAGS='<spec tags to run>'
+    ```
+
     * `kill` - Kills all running processes spun by the tests.
     * `clean_test` - Cleans all directories (`ruby-functional-tests/target`, `ruby-functional-tests/reports`).
     * `prepare` - Initializes the filesystem to run tests.
-    * `test` - Runs the gauge tests with specified tags. 
+    * `test` - Runs the gauge tests with specified tags.
     * `bump-schema` - Bump up schema version. Example: `VERSION=99 rake bump-schema`
+
+
+## Potential troubleshooting tips:
+
+### 1. Check that the GoCD server has started
+
+- Ensure that you have run the prepare step above, so that the server and agent are ready to be started.
+
+- Try and access http://localhost:8253
+
+- Check the logs in: `target/go-server-*/logs`
+
+### 2. Check resource/with-java.sh
+
+- It uses jabba to install Java if needed. Make sure that the version of Java being used is correct.
+
+### 3. Ensure that you have the right version of gauge-ruby installed.
+
+If you have the wrong version, it might show up like this:
+
+```shell
+$ bundle exec rake test GO_VERSION='20.4.0' GAUGE_TAGS='my-tags'
+bundle exec gauge --tags 'duck' run specs
+warning: parser/current is loading parser/ruby26, which recognizes
+warning: 2.6.0-dev-compliant syntax, but you are running 2.6.5.
+warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
+/path/to/ruby-functional-tests/vendor/bundle/ruby/2.6.0/gems/gauge-ruby-0.5.2/lib/connector.rb:34:in `initialize': Can't assign requested address - connect(2) for "127.0.0.1" port 0 (Errno::EADDRNOTAVAIL)
+	from /path/to/ruby-functional-tests/vendor/bundle/ruby/2.6.0/gems/gauge-ruby-0.5.2/lib/connector.rb:34:in `open'
+	from /path/to/ruby-functional-tests/vendor/bundle/ruby/2.6.0/gems/gauge-ruby-0.5.2/lib/connector.rb:34:in `make_connection'
+	from /path/to/ruby-functional-tests/vendor/bundle/ruby/2.6.0/gems/gauge-ruby-0.5.2/lib/gauge_runtime.rb:84:in `<module:Runtime>'
+	from /path/to/ruby-functional-tests/vendor/bundle/ruby/2.6.0/gems/gauge-ruby-0.5.2/lib/gauge_runtime.rb:33:in `<module:Gauge>'
+	from /path/to/ruby-functional-tests/vendor/bundle/ruby/2.6.0/gems/gauge-ruby-0.5.2/lib/gauge_runtime.rb:31:in `<top (required)>'
+	from -e:1:in `require'
+	from -e:1:in `<main>'
+Error occurred while waiting for runner process to finish.
+Error : exit status 1
+Error ----------------------------------
+
+[ruby]
+Ruby runner Failed. Reason: exit status 1
+
+[Gauge]
+Failed to start gauge API: Timed out connecting to ruby
+
+Get Support ----------------------------
+	Docs:          https://docs.gauge.org
+	Bugs:          https://github.com/getgauge/gauge/issues
+	Chat:          https://spectrum.chat/gauge
+
+Your Environment Information -----------
+	darwin, 1.0.8
+	html-report (4.0.10), ruby (0.5.3), screenshot (0.0.1)
+```
+
+You can see in the above output that the version of gauge-ruby in `vendor/bundle` is `gauge-ruby-0.5.2` and the version Gauge seems to be expect is `0.5.3` (that you can see in the "Your Environment Information" section at the end).
+
 
 ## License
 
 ```plain
-Copyright 2018 ThoughtWorks, Inc.
+Copyright 2020 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/resources/config/secure-cruise-config.xml
+++ b/resources/config/secure-cruise-config.xml
@@ -16,146 +16,146 @@
  *************************GO-LICENSE-END******************************* -->
 
 <cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="136">
-    <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
-        <artifacts>
-            <artifactsDir>artifacts</artifactsDir>
-        </artifacts>
-        <security>
-          <authConfigs>
-              <authConfig id="61f10215-9fba-4962-a2f4-d6c8944ade32" pluginId="cd.go.authentication.passwordfile">
-                  <property>
-                      <key>PasswordFilePath</key>
-                      <value>$password_properties</value>
-                  </property>
-              </authConfig>
-          </authConfigs>
-            <roles>
-                <role name="admins">
-                    <users>
-                        <user>admin</user>
-                        <user>pipelineSelectorAdmin</user>
-                    </users>
-                </role>
-                <role name="operator">
-                    <users>
-                        <user>operatorUser</user>
-                    </users>
-                </role>
-                <role name="viewer">
-                    <users>
-                        <user>view</user>
-                        <user>operate</user>
-                    </users>
-                </role>
-                <role name="misc">
-                    <users>
-                        <user>group1View</user>
-                    </users>
-                 </role>
-            </roles>
-            <admins>
-                <role>admins</role>
-            </admins>
-        </security>
-    </server>
-    <config-repos>
-       <config-repo id="config-repo-with-rules" pluginId="json.config.plugin">
-         <git url="material-for-pipeline-git-config-repo" />
-           <rules>
-             <allow action="refer" type="environment">team1-*</allow>
-             <allow action="refer" type="pipeline">team1-*</allow>
-             <allow action="refer" type="pipeline_group">configrepo</allow>
-             <deny action="refer" type="environment">team2-*</deny>
-             <deny action="refer" type="pipeline">team2-*</deny>
-             <deny action="refer" type="pipeline_group">team2-*</deny>
-           </rules>
-       </config-repo>
-        <config-repo id="config-repo-with-rules-on-group" pluginId="json.config.plugin">
-            <git url="material-for-config-repo-with-rules-on-group" />
-           <rules>
-             <deny action="refer" type="pipeline_group">configrepo</deny>
-             <allow action="refer" type="environment">config-repo-*</allow>
-           </rules>
-       </config-repo>
-    </config-repos>
-    <pipelines group="DEV_GROUP">
-      <pipeline name="In-group-DEV">
-        <environmentvariables>
-          <variable name="ENV_KEY">
-            <value>{{SECRET:[DEV][dev-password]}}</value>
-          </variable>
-        </environmentvariables>
-        <materials>
-          <git url="material-for-In-group-DEV" dest="git" materialName="git" autoUpdate="true" />
-        </materials>
-        <stage name="defaultStage">
-          <approval type="manual"/>
-          <jobs>
-            <job name="defaultJob">
-              <tasks>
-                <exec command="/bin/bash">
-                  <arg>-c</arg>
-                  <arg>echo "Using env var : $ENV_KEY"</arg>
-                </exec>
-              </tasks>
-            </job>
-          </jobs>
-        </stage>
-      </pipeline>
-    </pipelines>
-    <pipelines group="TEST_GROUP">
-      <pipeline name="In-group-TEST">
-        <environmentvariables>
-          <variable name="ENV_KEY">
-            <value>{{SECRET:[TEST][test-password]}}</value>
-          </variable>
-        </environmentvariables>
-        <materials>
-          <git url="material-for-In-group-TEST" dest="git" materialName="git" autoUpdate="true" />
-        </materials>
-        <stage name="defaultStage">
-          <approval type="manual"/>
-          <jobs>
-            <job name="defaultJob">
-              <tasks>
-                <exec command="/bin/bash">
-                  <arg>-c</arg>
-                  <arg>echo "Using env var : $ENV_KEY"</arg>
-                </exec>
-              </tasks>
-            </job>
-          </jobs>
-        </stage>
-      </pipeline>
-    </pipelines>
-    <pipelines group="PROD_GROUP">
-      <pipeline name="In-group-PROD">
-        <environmentvariables>
-          <variable name="ENV_KEY">
-            <value>{{SECRET:[PROD][prod-password]}}</value>
-          </variable>
-        </environmentvariables>
-        <materials>
-          <git url="material-for-In-group-PROD" dest="git" materialName="git" autoUpdate="true" />
-        </materials>
-        <stage name="defaultStage">
-          <approval type="manual"/>
-          <jobs>
-            <job name="defaultJob">
-              <tasks>
-                <exec command="/bin/bash">
-                  <arg>-c</arg>
-                  <arg>echo "Using env var : $ENV_KEY"</arg>
-                </exec>
-              </tasks>
-            </job>
-          </jobs>
-        </stage>
-      </pipeline>
+  <server commandRepositoryLocation="default" serverId="gauge" tokenGenerationKey="token">
+    <artifacts>
+      <artifactsDir>artifacts</artifactsDir>
+    </artifacts>
+    <security>
+      <authConfigs>
+        <authConfig id="61f10215-9fba-4962-a2f4-d6c8944ade32" pluginId="cd.go.authentication.passwordfile">
+          <property>
+            <key>PasswordFilePath</key>
+            <value>$password_properties</value>
+          </property>
+        </authConfig>
+      </authConfigs>
+      <roles>
+        <role name="admins">
+          <users>
+            <user>admin</user>
+            <user>pipelineSelectorAdmin</user>
+          </users>
+        </role>
+        <role name="operator">
+          <users>
+            <user>operatorUser</user>
+          </users>
+        </role>
+        <role name="viewer">
+          <users>
+            <user>view</user>
+            <user>operate</user>
+          </users>
+        </role>
+        <role name="misc">
+          <users>
+            <user>group1View</user>
+          </users>
+        </role>
+      </roles>
+      <admins>
+        <role>admins</role>
+      </admins>
+    </security>
+  </server>
+  <config-repos>
+    <config-repo id="config-repo-with-rules" pluginId="json.config.plugin">
+      <git url="material-for-pipeline-git-config-repo" />
+      <rules>
+        <allow action="refer" type="environment">team1-*</allow>
+        <allow action="refer" type="pipeline">team1-*</allow>
+        <allow action="refer" type="pipeline_group">configrepo</allow>
+        <deny action="refer" type="environment">team2-*</deny>
+        <deny action="refer" type="pipeline">team2-*</deny>
+        <deny action="refer" type="pipeline_group">team2-*</deny>
+      </rules>
+    </config-repo>
+    <config-repo id="config-repo-with-rules-on-group" pluginId="json.config.plugin">
+      <git url="material-for-config-repo-with-rules-on-group" />
+      <rules>
+        <deny action="refer" type="pipeline_group">configrepo</deny>
+        <allow action="refer" type="environment">config-repo-*</allow>
+      </rules>
+    </config-repo>
+  </config-repos>
+  <pipelines group="DEV_GROUP">
+    <pipeline name="In-group-DEV">
+      <environmentvariables>
+        <variable name="ENV_KEY">
+          <value>{{SECRET:[DEV][dev-password]}}</value>
+        </variable>
+      </environmentvariables>
+      <materials>
+        <git url="material-for-In-group-DEV" dest="git" materialName="git" autoUpdate="true" />
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo "Using env var : $ENV_KEY"</arg>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
+  <pipelines group="TEST_GROUP">
+    <pipeline name="In-group-TEST">
+      <environmentvariables>
+        <variable name="ENV_KEY">
+          <value>{{SECRET:[TEST][test-password]}}</value>
+        </variable>
+      </environmentvariables>
+      <materials>
+        <git url="material-for-In-group-TEST" dest="git" materialName="git" autoUpdate="true" />
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo "Using env var : $ENV_KEY"</arg>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
+  <pipelines group="PROD_GROUP">
+    <pipeline name="In-group-PROD">
+      <environmentvariables>
+        <variable name="ENV_KEY">
+          <value>{{SECRET:[PROD][prod-password]}}</value>
+        </variable>
+      </environmentvariables>
+      <materials>
+        <git url="material-for-In-group-PROD" dest="git" materialName="git" autoUpdate="true" />
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo "Using env var : $ENV_KEY"</arg>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-    </pipelines>
-    <pipelines group="VSM.Analytics">
-     <authorization>
+  </pipelines>
+  <pipelines group="VSM.Analytics">
+    <authorization>
       <view>
         <user>group1Admin</user>
         <user>view</user>
@@ -164,62 +164,62 @@
       <admins>
         <user>group1Admin</user>
       </admins>
-     </authorization>
+    </authorization>
 
-        <pipeline name="VSM1">
-            <materials>
-                <git url="material-for-pipeline_VSM1" dest="git" materialName="git" autoUpdate="true"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                     <tasks>
-                          <exec command="sleep">
-                            <arg>5</arg>
-                            <runif status="passed"/>
-                          </exec>
-                     </tasks>
-                   </job>
-                </jobs>
-            </stage>
-        </pipeline>
-         <pipeline name="VSM2">
-            <materials>
-                 <pipeline pipelineName="VSM1" stageName="defaultStage" materialName="VSM1" />
-            </materials>
-            <stage name="defaultStage">
-                 <jobs>
-                  <job name="defaultJob">
-                     <tasks>
-                          <exec command="sleep">
-                            <arg>5</arg>
-                            <runif status="passed"/>
-                          </exec>
-                     </tasks>
-                 </job>
-                </jobs>
-            </stage>
-       </pipeline>
-      <pipeline name="VSM3">
-       <materials>
-        <pipeline pipelineName="VSM1" stageName="defaultStage" materialName="VSM1" />
-        <git url="material-for-pipeline_VSM3" dest="git" materialName="git" autoUpdate="true"/>
-       </materials>
-       <stage name="defaultStage">
+    <pipeline name="VSM1">
+      <materials>
+        <git url="material-for-pipeline_VSM1" dest="git" materialName="git" autoUpdate="true"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
         <jobs>
           <job name="defaultJob">
-           <tasks>
+            <tasks>
               <exec command="sleep">
-                 <arg>5</arg>
-                 <runif status="passed"/>
+                <arg>5</arg>
+                <runif status="passed"/>
               </exec>
-           </tasks>
+            </tasks>
           </job>
         </jobs>
-       </stage>
-     </pipeline>
-     <pipeline name="VSM4">
+      </stage>
+    </pipeline>
+    <pipeline name="VSM2">
+      <materials>
+        <pipeline pipelineName="VSM1" stageName="defaultStage" materialName="VSM1" />
+      </materials>
+      <stage name="defaultStage">
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>5</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="VSM3">
+      <materials>
+        <pipeline pipelineName="VSM1" stageName="defaultStage" materialName="VSM1" />
+        <git url="material-for-pipeline_VSM3" dest="git" materialName="git" autoUpdate="true"/>
+      </materials>
+      <stage name="defaultStage">
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>5</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="VSM4">
       <materials>
         <pipeline pipelineName="VSM2" stageName="defaultStage" materialName="VSM2" />
         <pipeline pipelineName="VSM3" stageName="defaultStage" materialName="VSM3" />
@@ -229,8 +229,8 @@
           <job name="defaultJob">
             <tasks>
               <exec command="sleep">
-                 <arg>5</arg>
-                 <runif status="passed"/>
+                <arg>5</arg>
+                <runif status="passed"/>
               </exec>
             </tasks>
           </job>
@@ -241,7 +241,7 @@
   <pipelines group="VSM.Analytics.Rerun">
     <pipeline name="Rerun1">
       <materials>
-         <git url="material-for-pipeline_R1" dest="git" materialName="git" autoUpdate="true"/>
+        <git url="material-for-pipeline_R1" dest="git" materialName="git" autoUpdate="true"/>
       </materials>
       <stage name="defaultStage">
         <approval type="manual"/>
@@ -282,9 +282,9 @@
       <stage name="defaultStage">
         <jobs>
           <job name="defaultJob">
-             <tasks>
-                <exec command="rake" args="wait_or_fail" workingdir="git"/>
-             </tasks>
+            <tasks>
+              <exec command="rake" args="wait_or_fail" workingdir="git"/>
+            </tasks>
           </job>
         </jobs>
       </stage>
@@ -308,345 +308,375 @@
       </stage>
     </pipeline>
   </pipelines>
-    <pipelines group="admin-only">
-    <authorization>
-        <admins>
-          <user>admin</user>
-          <user>group1Admin</user>
-        </admins>
-      </authorization>
-      <pipeline name="In-env-PROD">
-        <materials>
-          <git url="material-for-In-env-PROD" dest="git" materialName="git" autoUpdate="true" />
-        </materials>
-        <stage name="defaultStage">
-          <approval type="manual"/>
-          <jobs>
-            <job name="defaultJob">
-              <tasks>
-                <exec command="/bin/bash">
-                  <arg>-c</arg>
-                  <arg>echo "Using environment level var : $ENV_LEVEL_VARIABLE"</arg>
-                </exec>
-              </tasks>
-            </job>
-          </jobs>
-        </stage>
-      </pipeline>
-      <pipeline name="team1-stage-test">
-          <materials>
-              <git url="material-for-team1-prod-test" dest="git" materialName="git" autoUpdate="false"/>
-          </materials>
-          <stage name="defaultStage">
-              <approval type="manual"/>
-              <jobs>
-              <job name="defaultJob">
-                  <tasks>
-                    <exec command="ls"/>
-                  </tasks>
-              </job>
-              </jobs>
-          </stage>
-      </pipeline>
-      <pipeline name="team2-stage-test">
-          <materials>
-              <git url="material-for-team2-prod-test" dest="git" materialName="git" autoUpdate="false"/>
-          </materials>
-          <stage name="defaultStage">
-              <approval type="manual"/>
-              <jobs>
-              <job name="defaultJob">
-                  <tasks>
-                    <exec command="ls"/>
-                  </tasks>
-              </job>
-              </jobs>
-          </stage>
-      </pipeline>
-      <pipeline name="admin-pipeline-api">
-            <materials>
-                <git url="material-for-admin-pipeline-api" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                      <exec command="ls"/>
-                    </tasks>
-                </job>
-                </jobs>
-            </stage>
-        </pipeline>
-        <pipeline name="admin-pipeline" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="material-for-admin-pipeline" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                    <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                    </tasks>
-                </job>
-                </jobs>
-            </stage>
-            <stage name="secondStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                    <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                    </tasks>
-                </job>
-                </jobs>
-            </stage>
-            </pipeline>
-    </pipelines>
-    <pipelines group="viewable">
-        <authorization>
-            <view>
-                <role>viewer</role>
-                <role>operator</role>
-            </view>
-            <operate>
-                <user>operate</user>
-                <role>operator</role>
-            </operate>
-        </authorization>
-        <pipeline name="failing-pipeline">
-          <materials>
-            <git url="material-for-failing-pipeline" dest="git" materialName="gitMaterial" autoUpdate="false"/>
-          </materials>
-          <stage name="defaultStage">
-            <approval type="manual"/>
-            <jobs>
-              <job name="defaultJob">
-                <tasks>
-                  <exec command="rake" args="wait_and_fail" workingdir="git"/>
-                </tasks>
-              </job>
-            </jobs>
-          </stage>
-        </pipeline>
-        <pipeline name="viewable-pipeline">
-             <materials>
-                <git url="material-for-viewable-pipeline" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                     <tasks>
-                          <exec command="sleep">
-                            <arg>5</arg>
-                            <runif status="passed"/>
-                          </exec>
-                     </tasks>
-                   </job>
-                </jobs>
-            </stage>
-        </pipeline>
-
-        <pipeline name="pipeline-with-stage-security">
-            <materials>
-                <hg url="material-for-pipeline-with-stage-security" dest="hg" autoUpdate="false"/>
-            </materials>
-            <stage name="first">
-                <approval type="manual">
-                    <authorization>
-                        <user>operate</user>
-                        <role>operator</role>
-                    </authorization>
-                </approval>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <ant target="run.till.file.exists" workingdir="hg/dev"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
-
-        <pipeline name="pipeline-with-auto-stage-security">
-            <materials>
-                <git url="material-for-pipeline-with-stage-security" dest="git" autoUpdate="false"/>
-            </materials>
-            <stage name="first">
-                <approval type="success">
-                    <authorization>
-                        <user>operate</user>
-                        <role>operator</role>
-                    </authorization>
-                </approval>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                          <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                      </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
-
-        <pipeline name="2-stage-viewable">
-            <materials>
-                <git url="material-for-2-stage-viewable-pipeline" dest="git" autoUpdate="false"/>
-            </materials>
-            <stage name="first">
-                <approval type="manual">
-                    <authorization>
-                        <user>operate</user>
-                    </authorization>
-                </approval>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-            <stage name="second">
-                <approval type="manual">
-                    <authorization>
-                        <user>admin</user>
-                    </authorization>
-                </approval>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
-    </pipelines>
-    <pipelines group="open-to-all">
-        <pipeline name="manual-stages-that-run-till-file-exists">
-            <materials>
-                <git url="material-for-manual-stages-that-run-till-file-exists" dest="git" materialName="gitMaterial" autoUpdate="false"/>
-            </materials>
-            <stage name="firstStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                    <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                    </tasks>
-                </job>
-                </jobs>
-            </stage>
-            <stage name="secondStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                    <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                    </tasks>
-                </job>
-                </jobs>
-            </stage>
-        </pipeline>
-        <pipeline name="basic-pipeline-for-cctray">
-         <materials>
-          <git url="material-for-basic-pipeline-for-cctray" dest="git" autoUpdate="false" materialName="git-material"/>
-         </materials>
-         <stage name="defaultStage">
-            <approval type="manual"/>
-            <jobs>
-              <job name="basic-pipeline-for-cctray-job">
-               <tasks>
-                    <exec command="rake" args="wait_or_fail" workingdir="git"/>
-               </tasks>
-              </job>
-              <job name="passing-job">
-                <tasks>
-                    <exec command="sleep">
-                      <arg>15</arg>
-                      <runif status="passed"/>
-                    </exec>
-                </tasks>
+  <pipelines group="group-with-no-auth">
+    <pipeline name="pipeline-in-group-with-no-auth">
+      <materials>
+        <git url="material-for-pipeline-in-group-with-no-auth" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls">
+              </exec>
+            </tasks>
           </job>
         </jobs>
       </stage>
     </pipeline>
-    </pipelines>
-    <pipelines group="basic">
-      <authorization>
-        <admins>
-          <user>group1Admin</user>
-        </admins>
-        <operate>
-                <user>operate</user>
-       </operate>
-          <view>
-              <role>viewer</role>
-              <role>operator</role>
-          </view>
-      </authorization>
-           <pipeline name="pipeline-with-elastic-agent-profile">
-            <materials>
-                 <git url="https://github.com/gocd/ruby-functional-tests.git" shallowClone="true" dest="git" materialName="git" autoUpdate="true"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual" />
-                 <jobs>
-                  <job name="defaultJob">
-                     <tasks>
-                          <exec command="ls">
-                          </exec>
-                     </tasks>
-                 </job>
-                </jobs>
-            </stage>
-       </pipeline>
-        <pipeline name="pipeline-with-elastic-agent-profile-1">
-            <materials>
-                <git url="https://github.com/gocd/ruby-functional-tests.git" shallowClone="true" dest="git" materialName="git" autoUpdate="true"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual" />
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="/bin/bash">
-                                <arg>-c</arg>
-                                <arg>echo CLUSTER_NAME=$CLUSTER_NAME</arg>
-                                <runif status="passed"/>
-                            </exec>
-                            <exec command="sleep">
-                                <arg>30</arg>
-                                <runif status="passed"/>
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
-        <pipeline name="pipeline-with-elastic-agent-profile-2">
-            <materials>
-                <git url="https://github.com/gocd/ruby-functional-tests.git" shallowClone="true" dest="git" materialName="git" autoUpdate="true"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual" />
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="/bin/bash">
-                                <arg>-c</arg>
-                                <arg>echo CLUSTER_NAME=$CLUSTER_NAME</arg>
-                                <runif status="passed"/>
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
-     <pipeline name="downstream-pipeline">
+  </pipelines>
+
+  <pipelines group="admin-only">
+    <authorization>
+      <admins>
+        <user>admin</user>
+        <user>group1Admin</user>
+      </admins>
+    </authorization>
+    <pipeline name="In-env-PROD">
+      <materials>
+        <git url="material-for-In-env-PROD" dest="git" materialName="git" autoUpdate="true" />
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo "Using environment level var : $ENV_LEVEL_VARIABLE"</arg>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="team1-stage-test">
+      <materials>
+        <git url="material-for-team1-prod-test" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="team2-stage-test">
+      <materials>
+        <git url="material-for-team2-prod-test" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="admin-pipeline-api">
+      <materials>
+        <git url="material-for-admin-pipeline-api" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="admin-pipeline" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-admin-pipeline" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+      <stage name="secondStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
+  <pipelines group="viewable">
+    <authorization>
+      <view>
+        <role>viewer</role>
+        <role>operator</role>
+      </view>
+      <operate>
+        <user>operate</user>
+        <role>operator</role>
+      </operate>
+    </authorization>
+    <pipeline name="failing-pipeline">
+      <materials>
+        <git url="material-for-failing-pipeline" dest="git" materialName="gitMaterial" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_and_fail" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="viewable-pipeline">
+      <materials>
+        <git url="material-for-viewable-pipeline" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>5</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+
+    <pipeline name="pipeline-with-stage-security">
+      <materials>
+        <hg url="material-for-pipeline-with-stage-security" dest="hg" autoUpdate="false"/>
+      </materials>
+      <stage name="first">
+        <approval type="manual">
+          <authorization>
+            <user>operate</user>
+            <role>operator</role>
+          </authorization>
+        </approval>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <ant target="run.till.file.exists" workingdir="hg/dev"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+
+    <pipeline name="pipeline-with-auto-stage-security">
+      <materials>
+        <git url="material-for-pipeline-with-stage-security" dest="git" autoUpdate="false"/>
+      </materials>
+      <stage name="first">
+        <approval type="success">
+          <authorization>
+            <user>operate</user>
+            <role>operator</role>
+          </authorization>
+        </approval>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+
+    <pipeline name="2-stage-viewable">
+      <materials>
+        <git url="material-for-2-stage-viewable-pipeline" dest="git" autoUpdate="false"/>
+      </materials>
+      <stage name="first">
+        <approval type="manual">
+          <authorization>
+            <user>operate</user>
+          </authorization>
+        </approval>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+      <stage name="second">
+        <approval type="manual">
+          <authorization>
+            <user>admin</user>
+          </authorization>
+        </approval>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
+  <pipelines group="open-to-all">
+    <authorization>
+      <operate>
+        <role>viewer</role>
+        <role>operator</role>
+      </operate>
+      <view>
+        <role>viewer</role>
+        <role>operator</role>
+      </view>
+    </authorization>
+
+    <pipeline name="manual-stages-that-run-till-file-exists">
+      <materials>
+        <git url="material-for-manual-stages-that-run-till-file-exists" dest="git" materialName="gitMaterial" autoUpdate="false"/>
+      </materials>
+      <stage name="firstStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+      <stage name="secondStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="basic-pipeline-for-cctray">
+      <materials>
+        <git url="material-for-basic-pipeline-for-cctray" dest="git" autoUpdate="false" materialName="git-material"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="basic-pipeline-for-cctray-job">
+            <tasks>
+              <exec command="rake" args="wait_or_fail" workingdir="git"/>
+            </tasks>
+          </job>
+          <job name="passing-job">
+            <tasks>
+              <exec command="sleep">
+                <arg>15</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
+  <pipelines group="basic">
+    <authorization>
+      <admins>
+        <user>group1Admin</user>
+      </admins>
+      <operate>
+        <user>operate</user>
+      </operate>
+      <view>
+        <role>viewer</role>
+        <role>operator</role>
+      </view>
+    </authorization>
+    <pipeline name="pipeline-with-elastic-agent-profile">
+      <materials>
+        <git url="https://github.com/gocd/ruby-functional-tests.git" shallowClone="true" dest="git" materialName="git" autoUpdate="true"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual" />
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls">
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="pipeline-with-elastic-agent-profile-1">
+      <materials>
+        <git url="https://github.com/gocd/ruby-functional-tests.git" shallowClone="true" dest="git" materialName="git" autoUpdate="true"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual" />
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo CLUSTER_NAME=$CLUSTER_NAME</arg>
+                <runif status="passed"/>
+              </exec>
+              <exec command="sleep">
+                <arg>30</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="pipeline-with-elastic-agent-profile-2">
+      <materials>
+        <git url="https://github.com/gocd/ruby-functional-tests.git" shallowClone="true" dest="git" materialName="git" autoUpdate="true"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual" />
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo CLUSTER_NAME=$CLUSTER_NAME</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="downstream-pipeline">
       <materials>
         <pipeline pipelineName="basic-pipeline-fast" stageName="defaultStage"/>
         <git url="material-for-downstream-pipeline" dest="git" materialName="downstream_git_material">
@@ -666,7 +696,7 @@
         </jobs>
       </stage>
     </pipeline>
-      <pipeline name="pipeline-artifacts">
+    <pipeline name="pipeline-artifacts">
       <materials>
         <git url="material-for-pipeline-artifacts" materialName="junit-pipeline-artifacts" autoUpdate="false"/>
       </materials>
@@ -708,141 +738,152 @@
         </jobs>
       </stage>
     </pipeline>
-        <pipeline name="basic-pipeline-with-git-material">
-            <materials>
-                <git url="material-for-basic-pipeline-with-git-material" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="sleep">
-                                <arg>5</arg>
-                                <runif status="passed"/>
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="basic-pipeline-with-git-material">
+      <materials>
+        <git url="material-for-basic-pipeline-with-git-material" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>5</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-        <pipeline name="P1">
-            <materials>
-                <git url="material-for-analytics" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                        <exec command="rake" args="wait_or_fail" workingdir="git"/>
-                    </tasks>
-                    <resources>
-                        <resource>R1</resource>
-                    </resources>
+    <pipeline name="P1">
+      <materials>
+        <git url="material-for-analytics" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_or_fail" workingdir="git"/>
+            </tasks>
+            <resources>
+              <resource>R1</resource>
+            </resources>
 
-                </job>
-                </jobs>
-            </stage>
-            </pipeline>
-        <pipeline name="P2">
-            <materials>
-                <git url="material-for-analytics" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                    <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                    </tasks>
-                    <resources>
-                        <resource>R2</resource>
-                    </resources>
-                </job>
-                </jobs>
-            </stage>
-            </pipeline>
-        <pipeline name="basic-pipeline-with-all-materials">
-          <materials>
-           <hg url="http://Non-existing-material" dest="hg" materialName="hg" autoUpdate="false"/>
-           <svn url="http://Non-existing-material" dest="svn" materialName="svn" autoUpdate="false"/>
-           <git url="http://Non-existing-material" dest="git" materialName="git" autoUpdate="false"/>
-           <p4 port="http://nonexisting:6578" useTickets="true" dest="p4" materialName="p4" autoUpdate="false">
-           <view>//depot/... //p4test_1/...</view>
-            <filter>
-             <ignore pattern="*.ignore"/>
-            </filter>
-           </p4>
-          </materials>
-          <stage name="defaultStage">
-           <jobs>
-            <job name="defaultJob">
-             <tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="P2">
+      <materials>
+        <git url="material-for-analytics" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+            <resources>
+              <resource>R2</resource>
+            </resources>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="basic-pipeline-with-all-materials">
+      <materials>
+        <hg url="http://Non-existing-material" dest="hg" materialName="hg" autoUpdate="false"/>
+        <svn url="http://Non-existing-material" dest="svn" materialName="svn" autoUpdate="false"/>
+        <git url="http://Non-existing-material" dest="git" materialName="git" autoUpdate="false"/>
+        <p4 port="http://nonexisting:6578" useTickets="true" dest="p4" materialName="p4" autoUpdate="false">
+          <view>//depot/... //p4test_1/...</view>
+          <filter>
+            <ignore pattern="*.ignore"/>
+          </filter>
+        </p4>
+      </materials>
+      <stage name="defaultStage">
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
               <exec command="sleep" args="15"/>
-             </tasks>
-           </job>
-           </jobs>
-          </stage>
-         </pipeline>
-         <pipeline name="pipeline-with-3-stages" lockBehavior="lockOnFailure">
-            <materials>
-                 <git url="material-for-pipeline-with-3-stages" dest="git" autoUpdate="false" />
-             </materials>
-            <stage name="first">
-                 <approval type="manual" />
-             <jobs>
-                  <job name="defaultJob">
-                      <tasks>
-                          <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                      </tasks>
-                  </job>
-             </jobs>
-            </stage>
-            <stage name="second">
-             <approval type="manual" />
-             <jobs>
-               <job name="defaultJob">
-                <tasks>
-                     <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                </tasks>
-                </job>
-             </jobs>
-            </stage>
-            <stage name="third">
-             <approval type="manual" />
-              <jobs>
-                 <job name="defaultJob">
-                  <tasks>
-                     <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                  </tasks>
-                 </job>
-              </jobs>
-          </stage>
-       </pipeline>
-       <pipeline name="edit-pipeline">
-            <materials>
-                <git url="material-for-edit-pipeline" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                           <exec command="sleep">
-                                <arg>10</arg>
-                                <runif status="passed"/>
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="pipeline-with-3-stages" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-pipeline-with-3-stages" dest="git" autoUpdate="false" />
+      </materials>
+      <stage name="first">
+        <approval type="manual" />
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+      <stage name="second">
+        <approval type="manual" />
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+      <stage name="third">
+        <approval type="manual" />
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="edit-pipeline">
+      <materials>
+        <git url="material-for-edit-pipeline" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>10</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
 
-    </pipelines>
-    <pipelines group="lock-pipelines">
-     <pipeline name="pipeline-2-manual-stages-that-run-till-file-exists" lockBehavior="lockOnFailure">
+  <pipelines group="lock-pipelines">
+    <authorization>
+      <operate>
+        <role>viewer</role>
+        <role>operator</role>
+      </operate>
+      <view>
+        <role>viewer</role>
+        <role>operator</role>
+      </view>
+    </authorization>
+
+    <pipeline name="pipeline-2-manual-stages-that-run-till-file-exists" lockBehavior="lockOnFailure">
       <materials>
         <git url="material-for-pipeline-2-manual-stages-that-run-till-file-exists" dest="git" autoUpdate="false" materialName="gitMaterial"/>
       </materials>
@@ -861,21 +902,21 @@
         <jobs>
           <job name="defaultJob">
             <tasks>
-                  <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
             </tasks>
           </job>
         </jobs>
       </stage>
     </pipeline>
-     <pipeline name="pipeline-with-environment-variables">
-         <environmentvariables>
-          <variable name="PIPELINE_LEVEL_VARIABLE"><value>pipeline</value></variable>
-          <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_PIPELINE"><value>pipeline-overrides-env</value></variable>
-          <variable name="PIPELINE_LEVEL_VARIABLE_OVERRIDDEN_BY_STAGE"><value>does-not-matter</value></variable>
-         <variable name="PIPELINE_LEVEL_VARIABLE_OVERRIDDEN_BY_JOB"><value>does-not-matter</value></variable>
-         <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
-         <variable name="PIPELINE_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
-        </environmentvariables>
+    <pipeline name="pipeline-with-environment-variables">
+      <environmentvariables>
+        <variable name="PIPELINE_LEVEL_VARIABLE"><value>pipeline</value></variable>
+        <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_PIPELINE"><value>pipeline-overrides-env</value></variable>
+        <variable name="PIPELINE_LEVEL_VARIABLE_OVERRIDDEN_BY_STAGE"><value>does-not-matter</value></variable>
+        <variable name="PIPELINE_LEVEL_VARIABLE_OVERRIDDEN_BY_JOB"><value>does-not-matter</value></variable>
+        <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
+        <variable name="PIPELINE_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
+      </environmentvariables>
       <materials>
         <git url="material-for-environment-variables" dest="git" materialName="env-var-material" autoUpdate="false"/>
       </materials>
@@ -898,11 +939,11 @@
               <variable name="JOB_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
             </environmentvariables>
             <tasks>
-                <exec command="sleep">
-                    <arg>5</arg>
-                    <runif status="passed"/>
-                </exec>
-           </tasks>
+              <exec command="sleep">
+                <arg>5</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
           </job>
           <job name="another-job">
             <environmentvariables>
@@ -933,81 +974,81 @@
       </stage>
     </pipeline>
 
-        <pipeline name="downstream-pipeline-api">
-         <materials>
-           <pipeline pipelineName="basic-pipeline-fast-api" stageName="defaultStage"/>
-          <git url="material-for-downstream-pipeline" dest="git" materialName="downstream_git_material">
-           <filter>
+    <pipeline name="downstream-pipeline-api">
+      <materials>
+        <pipeline pipelineName="basic-pipeline-fast-api" stageName="defaultStage"/>
+        <git url="material-for-downstream-pipeline" dest="git" materialName="downstream_git_material">
+          <filter>
             <ignore pattern="**/*"/>
-           </filter>
-           </git>
-         </materials>
-         <stage name="defaultStage">
-           <approval type="manual"/>
-           <jobs>
-            <job name="defaultJob">
-             <tasks>
+          </filter>
+        </git>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
               <exec command="ls"/>
-             </tasks>
-            </job>
-           </jobs>
-          </stage>
-         </pipeline>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-         <pipeline name="run.till.file.exists-api">
-            <materials>
-                <git url="material-for-run.till.file.exists-api" dest="git" autoUpdate="false" materialName="git.material"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="sleep">
-                            <arg>40</arg>
-                            <runif status="passed"/>
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="run.till.file.exists-api">
+      <materials>
+        <git url="material-for-run.till.file.exists-api" dest="git" autoUpdate="false" materialName="git.material"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>40</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-        <pipeline name="basic-pipeline-fast-api">
-            <materials>
-                <git url="material-for-basic-pipeline-fast-api" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls">
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="basic-pipeline-fast-api">
+      <materials>
+        <git url="material-for-basic-pipeline-fast-api" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls">
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-        <pipeline name="basic-pipeline-slow" lockBehavior="lockOnFailure">
-          <materials>
-           <git url="material-for-basic-pipeline-slow" dest="git" autoUpdate="false"/>
-          </materials>
-          <stage name="defaultStage">
-           <approval type="manual"/>
-           <jobs>
-            <job name="defaultJob">
-              <tasks>
-                <exec command="sleep">
-                            <arg>60</arg>
-                            <runif status="passed"/>
-                </exec>
-              </tasks>
-            </job>
-           </jobs>
-          </stage>
-        </pipeline>
+    <pipeline name="basic-pipeline-slow" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-basic-pipeline-slow" dest="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="sleep">
+                <arg>60</arg>
+                <runif status="passed"/>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
     <pipeline name="environment-pipeline">
       <materials>
         <git url="material-for-environment-pipeline" dest="git" autoUpdate="false"/>
@@ -1076,195 +1117,209 @@
         </jobs>
       </stage>
     </pipeline>
-    </pipelines>
-    <pipelines group="operable">
-        <authorization>
-            <admins>
-                <user>operate</user>
-            </admins>
-            <operate>
-                <role>operator</role>
-            </operate>
-        </authorization>
-        <pipeline name="operable-pipeline">
-            <materials>
-                <hg url="material-for-operable-pipeline" dest="hg" autoUpdate="false" materialName="admin-pipeline-hg"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
-    </pipelines>
-    <pipelines group="group.with.dot">
-      <pipeline name="run.till.file.exists">
-            <materials>
-                <git url="material-for-pipeline" dest="git" autoUpdate="false" materialName="git.material"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+  </pipelines>
 
-        <pipeline name="basic-pipeline-fast">
-            <materials>
-                <git url="material-for-basic-pipeline-fast" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls">
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+  <pipelines group="operable">
+    <authorization>
+      <admins>
+        <user>operate</user>
+      </admins>
+      <operate>
+        <role>operator</role>
+      </operate>
+    </authorization>
+    <pipeline name="operable-pipeline">
+      <materials>
+        <hg url="material-for-operable-pipeline" dest="hg" autoUpdate="false" materialName="admin-pipeline-hg"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
 
-        <pipeline name="pipeline-run-till-file-exits" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="material-for-pipeline-run-till-file-exits" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+  <pipelines group="group.with.dot">
+    <authorization>
+      <operate>
+        <role>viewer</role>
+        <role>operator</role>
+      </operate>
+      <view>
+        <role>viewer</role>
+        <role>operator</role>
+      </view>
+    </authorization>
 
-        <pipeline name="wait-for-stop-job" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="material-for-wait-for-stop-job" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
-                            <exec command="/bin/bash">
-                                <arg>-c</arg>
-                                <arg>echo "Second task completed"</arg>
-                            </exec>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="run.till.file.exists">
+      <materials>
+        <git url="material-for-pipeline" dest="git" autoUpdate="false" materialName="git.material"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-        <pipeline name="run-forever" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="material-for-run-forever" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="rake" args="wait_forever" workingdir="git"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="basic-pipeline-fast">
+      <materials>
+        <git url="material-for-basic-pipeline-fast" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls">
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-        <pipeline name="timer-triggered" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="material-for-timer-triggered" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls" workingdir="git"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="pipeline-run-till-file-exits" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-pipeline-run-till-file-exits" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
-        <pipeline name="long-mdu" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="https://github.com/cirosantilli/test-many-commits-1m" dest="git" materialName="long_running_mdu" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                    <job name="defaultJob">
-                        <tasks>
-                            <exec command="ls" workingdir="git"/>
-                        </tasks>
-                    </job>
-                </jobs>
-            </stage>
-        </pipeline>
+    <pipeline name="wait-for-stop-job" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-wait-for-stop-job" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_for_stopjob_file" workingdir="git"/>
+              <exec command="/bin/bash">
+                <arg>-c</arg>
+                <arg>echo "Second task completed"</arg>
+              </exec>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+
+    <pipeline name="run-forever" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-run-forever" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="rake" args="wait_forever" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+
+    <pipeline name="timer-triggered" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-timer-triggered" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+
+    <pipeline name="long-mdu" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="https://github.com/cirosantilli/test-many-commits-1m" dest="git" materialName="long_running_mdu" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls" workingdir="git"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
 
 
-        <pipeline name="pipeline-with-failing-stage" lockBehavior="lockOnFailure">
-            <materials>
-                <git url="material-for-pipeline-with-failing-stage" dest="git" materialName="git" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-                <approval type="manual"/>
-                <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                    <exec command="executable-that-will-not-be-found"/>
-                    </tasks>
-                </job>
-                </jobs>
-            </stage>
-            <stage name="secondStage">
+    <pipeline name="pipeline-with-failing-stage" lockBehavior="lockOnFailure">
+      <materials>
+        <git url="material-for-pipeline-with-failing-stage" dest="git" materialName="git" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="executable-that-will-not-be-found"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+      <stage name="secondStage">
         <approval type="manual"/>
         <jobs>
           <job name="defaultJob">
             <tasks>
               <exec command="sleep">
-                            <arg>60</arg>
-                            <runif status="passed"/>
-                          </exec>
+                <arg>60</arg>
+                <runif status="passed"/>
+              </exec>
             </tasks>
           </job>
         </jobs>
       </stage>
-        </pipeline>
-        <pipeline name="basic-pipeline">
-            <materials>
-              <hg url="material-for-basic-pipeline" dest="hg" autoUpdate="false"/>
-            </materials>
-            <stage name="defaultStage">
-             <approval type="manual"/>
-              <jobs>
-                <job name="defaultJob">
-                   <tasks>
-                    <exec command="ls"/>
-                   </tasks>
-                </job>
-              </jobs>
-             </stage>
-          </pipeline>
-    </pipelines>
+    </pipeline>
+
+    <pipeline name="basic-pipeline">
+      <materials>
+        <hg url="material-for-basic-pipeline" dest="hg" autoUpdate="false"/>
+      </materials>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+  </pipelines>
 
 
   <pipelines group="group-for-dependency-walk-1">
@@ -1315,58 +1370,58 @@
     </pipeline>
   </pipelines>
 
-    <!-- Add this template creation and adding template admin to the spec ones API supports updating authoriztion -->
-    <templates>
-      <pipeline name="simple-pass">
-	        <stage name="defaultStage">
-	        	<approval type="manual"/>
-	        	<jobs>
-	            	<job name="defaultJob">
-	                    <tasks>
-	                        <exec command="ls"/>
-	                    </tasks>
-	                 </job>
-	            </jobs>
-		  	</stage>
-	  </pipeline>
-      <pipeline name="Template-With-Admin">
-        <authorization>
-          <admins>
-            <user>templateadmin</user>
-          </admins>
-        </authorization>
-        <stage name="defaultStage">
-            <approval type="manual"/>
-            <jobs>
-                <job name="defaultJob">
-                    <tasks>
-                        <exec command="ls" />
-                    </tasks>
-                </job>
-            </jobs>
-        </stage>
+  <!-- Add this template creation and adding template admin to the spec ones API supports updating authoriztion -->
+  <templates>
+    <pipeline name="simple-pass">
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls"/>
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
+    </pipeline>
+    <pipeline name="Template-With-Admin">
+      <authorization>
+        <admins>
+          <user>templateadmin</user>
+        </admins>
+      </authorization>
+      <stage name="defaultStage">
+        <approval type="manual"/>
+        <jobs>
+          <job name="defaultJob">
+            <tasks>
+              <exec command="ls" />
+            </tasks>
+          </job>
+        </jobs>
+      </stage>
     </pipeline>
   </templates>
-    <environments>
-  		<environment name="uat">
-  		  <environmentvariables>
-          <variable name="ENV_LEVEL_VARIABLE"><value>environment</value></variable>
-          <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_PIPELINE"><value>does-not-matter</value></variable>
-          <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_STAGE"><value>does-not-matter</value></variable>
-          <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_JOB"><value>does-not-matter</value></variable>
-          <variable name="ENVIRONMENT_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
-			  </environmentvariables>
-       <pipelines>
-       <pipeline name="pipeline-with-environment-variables"/>
-      </pipelines>
-      </environment>
-      <environment name="PROD_ENV">
+  <environments>
+    <environment name="uat">
       <environmentvariables>
-          <variable name="ENV_LEVEL_VARIABLE"><value>{{SECRET:[PROD][prod-password]}}</value></variable>
-			  </environmentvariables>
-        <pipelines>
-          <pipeline name="In-env-PROD"/>
-        </pipelines>
-      </environment>
-  	</environments>
+        <variable name="ENV_LEVEL_VARIABLE"><value>environment</value></variable>
+        <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_PIPELINE"><value>does-not-matter</value></variable>
+        <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_STAGE"><value>does-not-matter</value></variable>
+        <variable name="ENV_LEVEL_VARIABLE_OVERRIDDEN_BY_JOB"><value>does-not-matter</value></variable>
+        <variable name="ENVIRONMENT_LEVEL_VARIABLE_OVERRIDDEN_BY_TRIGGER"><value>does-not-matter</value></variable>
+      </environmentvariables>
+      <pipelines>
+        <pipeline name="pipeline-with-environment-variables"/>
+      </pipelines>
+    </environment>
+    <environment name="PROD_ENV">
+      <environmentvariables>
+        <variable name="ENV_LEVEL_VARIABLE"><value>{{SECRET:[PROD][prod-password]}}</value></variable>
+      </environmentvariables>
+      <pipelines>
+        <pipeline name="In-env-PROD"/>
+      </pipelines>
+    </environment>
+  </environments>
 </cruise>

--- a/specs/EditStagePermissions.spec
+++ b/specs/EditStagePermissions.spec
@@ -18,7 +18,7 @@ tags: Clicky Admin
 * On Stage settings page of pipeline "basic-pipeline-fast" stage "defaultStage"
 * Open "Permissions" tab - On Stage settings page
 * Verify option  "Inherit from the pipeline group" is selected
-* Verify that the message "There are no operate permissions configured for this stage nor its pipeline group. All Go users can operate on this stage." shows up - Already On Edit Stage Page
+* Verify that the message "There is no authorization configured for this stage nor its pipeline group. Only GoCD administrators can operate this stage." shows up - Already On Edit Stage Page
 * Verify that the message "All system administrators and pipeline group administrators can operate on this stage (this cannot be overridden)." shows up - Already On Edit Stage Page
 * Select "Specify locally"
 * Set "admin" as user name - On Permission tab

--- a/specs/PipelineApiSecurity.spec
+++ b/specs/PipelineApiSecurity.spec
@@ -5,7 +5,7 @@ PipelineApiSecurity
 Setup of contexts
 * Secure Configuration - setup
 * Login as "admin" - setup
-* Using pipeline "basic-pipeline-fast-api, viewable-pipeline, admin-pipeline-api" - setup
+* Using pipeline "pipeline-in-group-with-no-auth, basic-pipeline-fast-api, viewable-pipeline, admin-pipeline-api" - setup
 * With "1" live agents - setup
 * Capture go state "PipelineApiSecurity" - setup
 
@@ -19,17 +19,22 @@ tags: API Security, api
 * Enable auto update for pipeline "admin-pipeline-api"
 
 * As user "admin"
-* On Swift Dashboard Page
-* Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
-* Schedule should return code "202"
-* Wait till stage "defaultStage" completed - On Swift Dashboard page
-* Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
-* Schedule should return code "202"
-* Wait till stage "defaultStage" completed - On Swift Dashboard page
-* Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
+
+* Looking at pipeline "pipeline-in-group-with-no-auth" - On Swift Dashboard page
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
 
+* Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
+* Schedule should return code "202"
+* Wait till stage "defaultStage" completed - On Swift Dashboard page
+
+* Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
+* Schedule should return code "202"
+* Wait till stage "defaultStage" completed - On Swift Dashboard page
+
+* Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
+* Schedule should return code "202"
+* Wait till stage "defaultStage" completed - On Swift Dashboard page
 
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * With material "git" of type "git" for pipeline "basic-pipeline-fast-api"
@@ -49,40 +54,38 @@ tags: API Security, api
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * Using "2nd" revision of "git" of type "git" for pipeline "basic-pipeline-fast-api"
 * Schedule should return code "202"
+
 * Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
 * Using "2nd" revision of "git" of type "git" for pipeline "viewable-pipeline"
 * Schedule should return code "202"
+
 * Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
 * Using "2nd" revision of "git" of type "git" for pipeline "admin-pipeline-api"
-
 * Schedule should return code "202"
 
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
 * On Job details page of pipeline "basic-pipeline-fast-api" counter "2" stage "defaultStage" counter "1" job "defaultJob"
-
-
 * Verify console shows "2nd" commit for material "git" for "basic-pipeline-fast-api"
 
-* On Swift Dashboard Page
 * Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
 * On Job details page of pipeline "viewable-pipeline" counter "2" stage "defaultStage" counter "1" job "defaultJob"
-
-
 * Verify console shows "2nd" commit for material "git" for "viewable-pipeline"
 
-* On Swift Dashboard Page
 * Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
 * On Job details page of pipeline "admin-pipeline-api" counter "2" stage "defaultStage" counter "1" job "defaultJob"
-
 * Verify console shows "2nd" commit for material "git" for "admin-pipeline-api"
+
+
 
 * As user "view"
 
-* On Swift Dashboard Page
+* Looking at pipeline "pipeline-in-group-with-no-auth" - On Swift Dashboard page
+* Schedule should return code "403"
+
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
@@ -93,57 +96,56 @@ tags: API Security, api
 * Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
 * Schedule should return code "403"
 
-* On Swift Dashboard Page
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
+
 * Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
 * Schedule should return code "403"
+
 * Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
 * Schedule should return code "403"
 
-* On Swift Dashboard Page
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
-
 * On Job details page of pipeline "basic-pipeline-fast-api" counter "4" stage "defaultStage" counter "1" job "defaultJob"
-
 * Verify console shows "0th" commit for material "git" for "basic-pipeline-fast-api"
+
+
 
 * As user "operate"
 
+* Looking at pipeline "pipeline-in-group-with-no-auth" - On Swift Dashboard page
+* Schedule should return code "403"
 
-* On Swift Dashboard Page
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
+
 * Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
+
 * Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
 * Schedule should return code "403"
-
-
-
 
 * Looking at pipeline "basic-pipeline-fast-api" - On Swift Dashboard page
 * Using "2nd" revision of "git" of type "git" for pipeline "basic-pipeline-fast-api"
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
+
 * Looking at pipeline "viewable-pipeline" - On Swift Dashboard page
 * Using "2nd" revision of "git" of type "git" for pipeline "viewable-pipeline"
 * Schedule should return code "202"
 * Wait till stage "defaultStage" completed - On Swift Dashboard page
+
 * Looking at pipeline "admin-pipeline-api" - On Swift Dashboard page
 * Using "2nd" revision of "git" of type "git" for pipeline "admin-pipeline-api"
 * Schedule should return code "403"
 * On Job details page of pipeline "basic-pipeline-fast-api" counter "6" stage "defaultStage" counter "1" job "defaultJob"
-
 * Verify console shows "2nd" commit for material "git" for "basic-pipeline-fast-api"
 
 * On Job details page of pipeline "viewable-pipeline" counter "4" stage "defaultStage" counter "1" job "defaultJob"
 * Verify console shows "2nd" commit for material "git" for "viewable-pipeline"
-
-
 
 
 


### PR DESCRIPTION
In https://github.com/gocd/gocd/pull/8034, the default permission for pipeline groups without any authorization defined is to deny, rather than allow everyone to be viewers and operators.

While reviewing, turn off whitespace changes: https://github.com/gocd/ruby-functional-tests/pull/651/files?diff=unified&w=1

Approach taken: Since the default permissions are changing, the configuration is changed to make it similar to the earlier setup.

Also: Changed one spec to verify https://github.com/gocd/gocd/pull/8034: This is done: [here](https://github.com/gocd/ruby-functional-tests/pull/651/files#diff-e11b04bb0bbb4d23bee82e3b56f75558R23), [here](https://github.com/gocd/ruby-functional-tests/pull/651/files#diff-e11b04bb0bbb4d23bee82e3b56f75558R86) and [here](https://github.com/gocd/ruby-functional-tests/pull/651/files#diff-e11b04bb0bbb4d23bee82e3b56f75558R117).