### PR TITLE
Add specs to verify manual stage trigger on dashboard.

### DIFF
--- a/resources/config/secure-cruise-config.xml
+++ b/resources/config/secure-cruise-config.xml
@@ -553,6 +553,7 @@
       <view>
         <role>viewer</role>
         <role>operator</role>
+        <user>user1</user>
       </view>
     </authorization>
 

--- a/specs/PipelineDashboardManualTrigger.spec
+++ b/specs/PipelineDashboardManualTrigger.spec
@@ -1,0 +1,61 @@
+PipelineDashboardManualTrigger
+============================
+
+Setup of contexts
+* Secure Configuration - setup
+* Login as "admin" - setup
+* Using pipeline "manual-stages-that-run-till-file-exists" - setup
+* With "1" live agents - setup
+* Capture go state "PipelineDashboardManualTrigger" - setup
+
+PipelineDashboardManualTrigger
+----------------------------
+
+tags: UI, refresh
+
+* Turn on AutoRefresh - On Swift Dashboard page
+* Looking at pipeline "manual-stages-that-run-till-file-exists" - On Swift Dashboard page
+
+* Verify pipeline has no history - On Swift Dashboard page
+* Trigger pipeline - On Swift Dashboard page
+* Verify stage "firstStage" is "Building" - On Swift Dashboard page
+* Verify cannot trigger pipeline
+
+* Verify stage "firstStage" does not have a manual gate - On Swift Dashboard page
+* Verify stage "secondStage" has a manual gate - On Swift Dashboard page
+* Verify stage "secondStage" has a manual gate in "disabled" state with message "Can not schedule next stage - Either the previous stage hasn't run or is in progress." - On Swift Dashboard page
+
+* Create a "stopjob" file
+* Verify stage "firstStage" is "Passed" - On Swift Dashboard page
+* Verify stage "firstStage" does not have a manual gate - On Swift Dashboard page
+* Verify stage "secondStage" has a manual gate - On Swift Dashboard page
+
+* Verify stage "secondStage" has a manual gate in "enabled" state with message "Awaiting approval. Waiting for users with the operate permission to schedule 'secondStage' stage" - On Swift Dashboard page
+
+* Manually trigger stage "secondStage" - On Swift Dashboard page
+
+* Verify stage "secondStage" has a manual gate in "disabled" state with message "Approved by 'admin'" - On Swift Dashboard page
+
+* Trigger pipeline - On Swift Dashboard page
+* Verify stage "firstStage" is "Building" - On Swift Dashboard page
+* Verify cannot trigger pipeline
+
+* Logout and login as "user1"
+* Looking at pipeline "manual-stages-that-run-till-file-exists" - On Swift Dashboard page
+
+* Verify stage "firstStage" does not have a manual gate - On Swift Dashboard page
+* Verify stage "secondStage" has a manual gate - On Swift Dashboard page
+* Verify stage "secondStage" has a manual gate in "disabled" state with message "Can not schedule next stage - You don't have permissions to schedule the next stage." - On Swift Dashboard page
+
+* Create a "stopjob" file
+* Verify stage "firstStage" is "Passed" - On Swift Dashboard page
+* Verify stage "firstStage" does not have a manual gate - On Swift Dashboard page
+* Verify stage "secondStage" has a manual gate - On Swift Dashboard page
+
+* Verify stage "secondStage" has a manual gate in "disabled" state with message "Can not schedule next stage - You don't have permissions to schedule the next stage." - On Swift Dashboard page
+
+Teardown of contexts
+____________________
+* Capture go state "PipelineDashboardManualTrigger" - teardown
+* Logout - from any page
+* With "1" live agents - teardown

--- a/step_implementations/specs/new_pipeline_dashboard_spec.rb
+++ b/step_implementations/specs/new_pipeline_dashboard_spec.rb
@@ -57,6 +57,26 @@ step 'Verify stage <stage> is <state> - On Swift Dashboard page' do |stage, stat
   new_pipeline_dashboard_page.verify_pipeline_stage_state scenario_state.get('current_pipeline'), stage, state.downcase
 end
 
+step 'Verify stage <stage> has a manual gate - On Swift Dashboard page' do |stage|
+  new_pipeline_dashboard_page.verify_pipeline_stage_is_manual scenario_state.get('current_pipeline'), stage
+end
+
+step 'Verify stage <stage> does not have a manual gate - On Swift Dashboard page' do |stage|
+  new_pipeline_dashboard_page.verify_pipeline_stage_is_not_manual scenario_state.get('current_pipeline'), stage
+end
+
+step 'Manually trigger stage <stage> - On Swift Dashboard page' do |stage|
+  new_pipeline_dashboard_page.manually_trigger_stage scenario_state.get('current_pipeline'), stage
+end
+
+step 'Verify stage <stage> has a manual gate in <state> state with message <message> - On Swift Dashboard page' do |stage, state, message|
+  enabled_manual_gate = state.include?("enabled")
+  new_pipeline_dashboard_page.verify_pipeline_stage_is_manual scenario_state.get('current_pipeline'), stage
+  new_pipeline_dashboard_page.verify_manual_stage_state scenario_state.get('current_pipeline'), stage, enabled_manual_gate
+  new_pipeline_dashboard_page.verify_manual_stage_message scenario_state.get('current_pipeline'), stage, message
+end
+
+
 step 'Trigger and cancel stage <defaultStage> <trigger_number> times' do |stage_name, trigger_number|
   scenario_state.put 'current_stage_name', stage_name
   new_pipeline_dashboard_page.trigger_cancel_pipeline trigger_number


### PR DESCRIPTION
- verify no manual gate shows up for first manual stage from the pipeline.
- verify manual gate for manual stages.
- verify enabled/disabled state of manual gates.
- verify triggering of manual stage.
- verify users with view permissions do not have access to trigger manual gate.