### PR TITLE
Add specs for older stages runs on the dashboard stage overview.

### DIFF
--- a/lib/pages/new_pipeline_dashboard_page.rb
+++ b/lib/pages/new_pipeline_dashboard_page.rb
@@ -473,6 +473,10 @@ module Pages
       assert_true page.find('div[data-test-id="stage-instance-container"]').text.include?(stage_counter)
     end
 
+    def select_stage_counter_from_stage_overview_header(counter)
+      page.find('select[data-test-id="form-field-input-"]').select counter
+    end
+
     def verify_stage_overview_triggered_by_user(username)
       assert_true page.find('div[data-test-id="triggered-by-container"]').text.include?(username)
     end

--- a/specs/DashboardStageOverviewOlderRuns.spec
+++ b/specs/DashboardStageOverviewOlderRuns.spec
@@ -1,0 +1,94 @@
+DashboardStageOverview
+============
+
+Setup of contexts
+
+Setup of contexts
+* Basic Configuration - setup
+* Using pipeline "pipeline-with-3-jobs" - setup
+* With "2" live agents - setup
+* Capture go state "DashboardStageOverview" - setup
+
+DashboardStageOverview
+------------
+
+tags: stage-overview, UI, refresh
+
+* Looking at pipeline "pipeline-with-3-jobs" - On Swift Dashboard page
+* Trigger pipeline - On Swift Dashboard page
+* Verify stage "defaultStage" is "Failing" on pipeline with label "1" - On Swift Dashboard page
+
+* Open stage overview for stage "defaultStage" - On Swift Dashboard page
+
+* Verify stage overview has header "pipeline-with-3-jobs" "1" "defaultStage" "1"
+
+* Wait for "20" seconds
+
+* Verify failed job count is "1"
+* Verify passed job count is "1"
+* Verify building job count is "1"
+
+* Verify "second" job is in "failed" state
+* Verify "first" job is in "unknown" state
+* Verify "third" job is in "passed" state
+
+* On Swift Dashboard Page
+* Create a "stopjob" file and validate pipeline completed
+* Verify stage "defaultStage" is "Failed" on pipeline with label "1" - On Swift Dashboard page
+
+* Open stage overview for stage "defaultStage" - On Swift Dashboard page
+
+* Verify failed job count is "1"
+* Verify passed job count is "2"
+* Verify building job count is "0"
+
+* Verify "second" job is in "failed" state
+* Verify "first" job is in "passed" state
+* Verify "third" job is in "passed" state
+
+* Rerun failed jobs
+
+* Wait for "11" seconds
+
+* Verify failed job count is "0"
+* Verify passed job count is "2"
+* Verify building job count is "1"
+
+* Verify "second" job is in "unknown" state
+* Verify "first" job is in "passed" state
+* Verify "third" job is in "passed" state
+
+* On Swift Dashboard Page
+* Create a "stopjob" file and validate pipeline completed
+
+* Open stage overview for stage "defaultStage" - On Swift Dashboard page
+
+* Verify stage overview has header "pipeline-with-3-jobs" "1" "defaultStage" "2"
+
+* Select stage counter "1" from stage overview header
+
+* Wait for "11" seconds
+
+* Verify failed job count is "1"
+* Verify passed job count is "2"
+* Verify building job count is "0"
+
+* Verify "second" job is in "failed" state
+* Verify "first" job is in "passed" state
+* Verify "third" job is in "passed" state
+
+* Rerun failed jobs
+
+* Wait for "11" seconds
+
+* Verify stage overview has header "pipeline-with-3-jobs" "1" "defaultStage" "3"
+
+* Verify failed job count is "0"
+* Verify passed job count is "2"
+* Verify building job count is "1"
+
+
+Teardown of contexts
+____________________
+* Capture go state "DashboardStageOverview" - teardown
+* With "2" live agents - teardown

--- a/step_implementations/specs/dashboard_stage_overview_spec.rb
+++ b/step_implementations/specs/dashboard_stage_overview_spec.rb
@@ -22,6 +22,10 @@ step 'Verify stage overview has header <pipeline> <pipeline_counter> <stage> <st
   new_pipeline_dashboard_page.verify_stage_overview_header pipeline, pipeline_counter, stage, stage_counter
 end
 
+step 'Select stage counter <counter> from stage overview header' do |counter|
+  new_pipeline_dashboard_page.select_stage_counter_from_stage_overview_header counter
+end
+
 step 'Verify stage overview renders stage triggered by <username>' do |username|
   new_pipeline_dashboard_page.verify_stage_overview_triggered_by_user username
 end


### PR DESCRIPTION
* Verify older runs dropdown shows up for stages which are run
  more than 1s.

* Ability to navigate to an older stage run.

* Ability to navigate to an older stage run and rerun failed jobs.