### PR TITLE
Add specs to start GoCD Server in maintenance mode.

### DIFF
--- a/lib/context/server.rb
+++ b/lib/context/server.rb
@@ -57,7 +57,9 @@ module Context
       log_location = "#{GoConstants::SERVER_DIR}/logs/output.log"
       out = File.open(log_location, 'a')
       out.sync = true
-      prepare_wrapper_conf(GoConstants::GO_SERVER_SYSTEM_PROPERTIES)
+      properties = GoConstants::GO_SERVER_SYSTEM_PROPERTIES
+      properties.push(ENV['ADDITIONAL_SERVER_SYSTEM_PROPERITES'])
+      prepare_wrapper_conf(properties)
 
       STDERR.puts "Attempting to re-start GoCD server in: #{GoConstants::SERVER_DIR}.}"
       Bundler.with_original_env do

--- a/specs/StartServerInMaintenanceMode.spec
+++ b/specs/StartServerInMaintenanceMode.spec
@@ -1,0 +1,50 @@
+StartServerInMaintenanceMode
+=========
+
+StartServerInMaintenanceMode
+-------------------
+tags: drain_mode
+
+Setup of contexts
+* Secure Configuration - setup
+* Login as "admin" - setup
+* Using pipeline "wait-for-stop-job, basic-pipeline-fast, timer-triggered" - setup
+* Capture go state "StartServerInMaintenanceMode" - setup
+
+* On Maintenance mode SPA
+* Verify server is not in maintenance mode
+
+* On Swift Dashboard Page
+* Verify maintenance mode banner is not shown
+
+* Specify system property to start GoCD Server in maintenance mode
+
+* Logout - from any page
+* Restart server
+* Login as "admin"
+
+* On Maintenance mode SPA
+* Verify server is in maintenance mode
+
+* On Swift Dashboard Page
+* Verify maintenance mode banner is shown
+
+* Remove system property to start GoCD Server in maintenance mode
+
+* Logout - from any page
+* Restart server
+* Login as "admin"
+
+* On Maintenance mode SPA
+* Verify server is not in maintenance mode
+
+* On Swift Dashboard Page
+* Verify maintenance mode banner is not shown
+
+
+teardown
+_______________
+* As user "admin" for teardown
+* Maintenance mode - teardown
+* Logout - from any page
+* Capture go state "StartServerInMaintenanceMode" - teardown

--- a/step_implementations/go_constants.rb
+++ b/step_implementations/go_constants.rb
@@ -84,5 +84,5 @@ class GoConstants
                                    -Dcruise.server.ssl.port=#{SERVER_SSL_PORT}
                                    -Xms#{SERVER_MEM}
                                    -Xmx#{SERVER_MAX_MEM}
-                                   #{ENV['ADDITIONAL_SERVER_SYSTEM_PROPERITES']}].freeze
+                                   #{ENV['ADDITIONAL_SERVER_SYSTEM_PROPERITES']}]
 end

--- a/step_implementations/specs/maintenance_mode_spa_spec.rb
+++ b/step_implementations/specs/maintenance_mode_spa_spec.rb
@@ -54,6 +54,14 @@ step 'Verify maintenance mode banner is not shown' do
   assert_false maintenance_mode_page.maintenance_mode_banner_shown?
 end
 
+step 'Specify system property to start GoCD Server in maintenance mode' do
+  ENV['ADDITIONAL_SERVER_SYSTEM_PROPERITES'] = "-Dgocd.server.start.in.maintenance.mode=true"
+end
+
+step 'Remove system property to start GoCD Server in maintenance mode' do
+  ENV['ADDITIONAL_SERVER_SYSTEM_PROPERITES'] = "-Dgocd.server.start.in.maintenance.mode=false"
+end
+
 step 'Cancel pipeline <pipeline> counter <p_counter> stage <stage> counter <s_counter> - On Maintenance mode spa' do |pipeline, p_counter, stage, s_counter|
   maintenance_mode_page.cancel_stage(scenario_state.get(pipeline), p_counter, stage, s_counter)
 end
@@ -65,6 +73,10 @@ end
 
 step 'Verify in progress subsystems section shows material <name>' do |name|
   maintenance_mode_page.shows_running_mdu_for_material(name)
+end
+
+step 'Verify server is in maintenance mode' do
+  assert_true maintenance_mode_page.maintenance_mode_enabled?
 end
 
 step 'Verify server is not in maintenance mode' do


### PR DESCRIPTION
* Specify the system property to start server in maintenance mode.

* Set the property value to false to verify GoCD Server does not
  start in maintenance mode.