### PR TITLE
Revert "Bump selenium-webdriver from 4.10.0 to 4.12.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     roar (1.2.0)
       representable (~> 3.1)
     rubyzip (2.3.2)
-    selenium-webdriver (4.12.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)


### PR DESCRIPTION
Reverts gocd/ruby-functional-tests#957

See https://github.com/SeleniumHQ/selenium/issues/12651